### PR TITLE
updating Jenkinsfile to use pipeline library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,14 +49,7 @@ pipeline {
 
   post {
     always {
-      sh 'sudo chown -R jenkins:jenkins .'
-      deleteDir()
-    }
-    failure {
-      slackSend(color: 'danger', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} FAILURE (<${env.BUILD_URL}|Open>)")
-    }
-    unstable {
-      slackSend(color: 'warning', message: "${env.JOB_NAME} #${env.BUILD_NUMBER} UNSTABLE (<${env.BUILD_URL}|Open>)")
+      cleanupAndNotify(currentBuild.currentResult)
     }
   }
 }


### PR DESCRIPTION
This PR replaces the old `post` section of the Jenkinsfile with the standardized `post` section in [the Jenkins pipeline library](https://github.com/conjurinc/jenkins-pipeline-library/blob/master/vars/cleanupAndNotify.groovy) in the interest of keeping things DRY. 

Jenkins build currently processing [here](https://jenkins.conjur.net/job/cyberark--summon/job/update-Jenkinsfile-post/