### PR TITLE
RFC: playground for suggested changes to summon WIP

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -13,8 +13,8 @@ var Flags = []cli.Flag{
 		Name:  "t, template",
 		Usage: "Template string for generating @SUMMONENVFILE",
 		Value: `
-{{- range . -}}
-	{{.Key}}={{.Value}}
+{{- range $key, $value := . -}}
+	{{$key}}={{$value}}
 {{ end -}}
 `,
 	},

--- a/command/flags.go
+++ b/command/flags.go
@@ -10,6 +10,15 @@ var Flags = []cli.Flag{
 		Usage: "Path to provider for fetching secrets",
 	},
 	cli.StringFlag{
+		Name:  "t, template",
+		Usage: "Template string for generating @SUMMONENVFILE",
+		Value: `
+{{- range . -}}
+	{{.Key}}={{.Value}}
+{{ end -}}
+`,
+	},
+	cli.StringFlag{
 		Name:  "e, environment",
 		Usage: "Specify section/environment to parse from secrets.yaml",
 	},

--- a/command/flags.go
+++ b/command/flags.go
@@ -9,14 +9,10 @@ var Flags = []cli.Flag{
 		Name:  "p, provider",
 		Usage: "Path to provider for fetching secrets",
 	},
-	cli.StringFlag{
+	cli.StringSliceFlag{
 		Name:  "t, template",
-		Usage: "Template string for generating @SUMMONENVFILE",
-		Value: `
-{{- range $key, $value := . -}}
-	{{$key}}={{$value}}
-{{ end -}}
-`,
+		Usage: "Path pairs of template source and destination separated by colon e.g. /from/path:to/path",
+		Value: &cli.StringSlice{},
 	},
 	cli.StringFlag{
 		Name:  "e, environment",

--- a/command/flags.go
+++ b/command/flags.go
@@ -32,4 +32,13 @@ var Flags = []cli.Flag{
 		Value: &cli.StringSlice{},
 		Usage: "Ignore the specified key if is isn't accessible or doesn’t exist",
 	},
+	cli.BoolFlag{
+		Name:  "watch, w",
+		Usage: "Watch for changes in secret values from provider then re-summon",
+	},
+	cli.IntFlag{
+		Name:  "watch-poll-interval",
+		Value: 5000,
+		Usage: "Polling interval when watching for changes in secret values from provider",
+	},
 }

--- a/command/temp_factory.go
+++ b/command/temp_factory.go
@@ -49,6 +49,28 @@ func (tf *TempFactory) Push(value string) string {
 	tf.files = append(tf.files, name)
 	return name
 }
+// pipes
+//func () {
+//	tmpDir, _ := ioutil.TempDir(tf.path, ".summon")
+//	// Create named pipe
+//	namedPipe := filepath.Join(tmpDir, "pipe")
+//	syscall.Mkfifo(namedPipe, 0600)
+//
+//	go func() {
+//		// a blocking file descriptor when writing
+//		f, _ := os.OpenFile(namedPipe, os.O_WRONLY, 0600)
+//		defer func() {
+//			// clean up
+//			f.Close()
+//			os.Remove(namedPipe)
+//			os.Remove(tmpDir)
+//		}()
+//		f.Write([]byte(value))
+//	}()
+//
+//	tf.files = append(tf.files, namedPipe)
+//	return namedPipe
+//}
 
 // Remove the temporary files created with this factory.
 func (tf *TempFactory) Cleanup() {

--- a/command/temp_factory.go
+++ b/command/temp_factory.go
@@ -49,28 +49,6 @@ func (tf *TempFactory) Push(value string) string {
 	tf.files = append(tf.files, name)
 	return name
 }
-// pipes
-//func () {
-//	tmpDir, _ := ioutil.TempDir(tf.path, ".summon")
-//	// Create named pipe
-//	namedPipe := filepath.Join(tmpDir, "pipe")
-//	syscall.Mkfifo(namedPipe, 0600)
-//
-//	go func() {
-//		// a blocking file descriptor when writing
-//		f, _ := os.OpenFile(namedPipe, os.O_WRONLY, 0600)
-//		defer func() {
-//			// clean up
-//			f.Close()
-//			os.Remove(namedPipe)
-//			os.Remove(tmpDir)
-//		}()
-//		f.Write([]byte(value))
-//	}()
-//
-//	tf.files = append(tf.files, namedPipe)
-//	return namedPipe
-//}
 
 // Remove the temporary files created with this factory.
 func (tf *TempFactory) Cleanup() {

--- a/command/temp_factory.go
+++ b/command/temp_factory.go
@@ -50,6 +50,17 @@ func (tf *TempFactory) Push(value string) string {
 	return name
 }
 
+// Create a temp file with given value. Returns the path.
+func (tf *TempFactory) PushTo(path, value string) string {
+	f, _ := os.OpenFile(path, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0777)
+	defer f.Close()
+
+	f.Write([]byte(value))
+	name := f.Name()
+	tf.files = append(tf.files, name)
+	return name
+}
+
 // Remove the temporary files created with this factory.
 func (tf *TempFactory) Cleanup() {
 	for _, file := range tf.files {

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Running development environment"
+
+docker-compose build --pull summon-builder
+
+docker-compose run --rm -v $(pwd):/go/src/github.com/cyberark/summon/ --entrypoint bash summon-builder


### PR DESCRIPTION
This PR is meant to initiate a discussion regarding summon's ability to restart applications when secrets change.

The approach presented is polling the secret provider at some given interval for new secret values. At any given time this solution creates a hash of the previous secret values and compares it to the latest values.

## To test: 
run `./dev.sh` to start the development environment.
test by running the following from within the development container
```
go build -v
```

1. watch mode - polls for changes to secret values
```
echo "SECRET: !var changing_secrets.txt" > secrets.yml;

# create a file called changing_secrets.txt 
# and proceed to modify it after running the command below

./summon -w -p /bin/cat /bin/bash -c '
while true
do
echo "---";
echo "SECRET: $SECRET";
sleep 2;
done
'
```
2. templates - use go templates to generate `@SUMMONENVFILE`
```
# database_password.secret
231231jk2b3j123k1b2k3j1bk23b1kj23b123
```
```
# secret.yml
DATABASE_PASSWORD: !var database_password.secret
```
```
#database.yml.tmpl
development:
  adapter: postgresql
  encoding: unicode
  database: sample_development
  username: postgres
  password: {{index . "DATABASE_PASSWORD"}}
  host: localhost
  port: 5432
```
```
# run in bash
$ ./summon -p /bin/cat -t database.yml.tmpl:database.yml cat database.yml 
development:
  adapter: postgresql
  encoding: unicode
  database: sample_development
  username: postgres
  password: 231231jk2b3j123k1b2k3j1bk23b1kj23b123
  host: localhost
  port: 5432

# observer that database.yml no longer exists after the process exits
```

Feel free to discuss the pros and cons of this particular approach and suggest other approaches. 

E.g. An approach that would be interesting is if secret providers could provide the date when the secret was last changed.
