### PR TITLE
Update README to fix example SUMMONENVFILE command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Using Docker? When you run summon it also exports the variables and values from 
 You can then pass secrets to your container using Docker's `--env-file` flag like so:
 
 ```sh
-summon docker run myorg/myimage --env-file @SUMMONENVFILE
+summon docker run --env-file @SUMMONENVFILE myorg/myimage
 ```
 
 This file is created on demand - only when `@SUMMONENVFILE` appears in the


### PR DESCRIPTION
This PR updates the README so that the example `docker run` command that uses `SUMMONENVFILE` is a valid command. At current, it lists the `--env-file` option before the `IMAGE`, which is not consistent with the [Docker run syntax](https://docs.docker.com/engine/reference/commandline/run/). In this PR, the order is switched so that the `--env-file` flag is before the `IMAGE` in the command.