### PR TITLE
Fixed escaping of godep path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ you can use `@SUMMONENVFILE` just the same.
 ## Development
 
 Dependencies are vendored with [godep](https://github.com/tools/godep).
-To make them available, run `export GOPATH=`godep path`:$GOPATH`.
+To make them available, run `export GOPATH=$(godep path):$GOPATH`.
 
 Run the project with:
 
 ```
-go run *.go`.
+go run *.go
 ```
 
 ### Testing


### PR DESCRIPTION
Since backticks are used to escape the code block,
the repeated backtick removes the formatting. Fixed the doc by
removing the backticks and using the generally more accepted
way of grabbing the output of a command with `$()`.

Also fixed stray backtick with period.