### PR TITLE
Add a GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,51 @@
+image: tmaier/docker-compose:18
+
+services:
+  - docker:dind
+
+stages:
+  - build
+  - test
+  - test-installer
+  - package
+
+before_script:
+  - apk add --no-cache bash make
+
+build:
+  stage: build
+  script:
+    - "./build.sh linux:amd64"
+  artifacts:
+    paths:
+      - output/summon-linux-amd64
+
+test-unit:
+  stage: test
+  script:
+    - ./test.sh
+  artifacts:
+    paths:
+      - output/junit.xml
+test-acceptance:
+  stage: test
+  script:
+    - cp ./output/summon-linux-amd64 summon
+    - cd acceptance && make
+test-installer-ubuntu1404:
+  stage: test
+  script:
+    - bin/installer-test --ubuntu-14.04
+test-installer-ubuntu1604:
+  stage: test
+  script:
+    - bin/installer-test --ubuntu-16.04
+
+package-tarballs:
+  stage: package
+  script:
+    - ./build.sh  # now build binaries for all distros
+    - ./package.sh
+  artifacts:
+    paths:
+      - output/dist/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
     }
     stage('Build Go binaries') {
       steps {
-        sh './build.sh'
-        archiveArtifacts artifacts: 'output/*', fingerprint: true
+        sh './build.sh linux:amd64'
+        archiveArtifacts artifacts: 'output/summon-linux-amd64', fingerprint: true
       }
     }
     stage('Run unit tests') {
@@ -57,6 +57,7 @@ pipeline {
 
     stage('Package distribution tarballs') {
       steps {
+        sh './build.sh'  // now build binaries for all distros
         sh './package.sh'
         archiveArtifacts artifacts: 'output/dist/*', fingerprint: true
       }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
   </a>
 </div>
 
+
+[![GitHub release](https://img.shields.io/github/release/cyberark/summon.svg)](https://github.com/cyberark/summon/releases/latest)
+[![pipeline status](https://gitlab.com/cyberark/summon/badges/master/pipeline.svg)](https://gitlab.com/cyberark/summon/commits/master)
+
+[![Github commits (since latest release)](https://img.shields.io/github/commits-since/cyberark/summon/latest.svg)](https://github.com/cyberark/summon/commits/master)
+
 ---
 
 `summon` is a command-line tool to make working with secrets easier.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   </a>
 </div>
 
-
 [![GitHub release](https://img.shields.io/github/release/cyberark/summon.svg)](https://github.com/cyberark/summon/releases/latest)
 [![pipeline status](https://gitlab.com/cyberark/summon/badges/master/pipeline.svg)](https://gitlab.com/cyberark/summon/commits/master)
 

--- a/acceptance/Makefile
+++ b/acceptance/Makefile
@@ -2,7 +2,6 @@
 
 # currently built ad-hoc based on modified buncker
 TEST_HARNESS = conjurinc/summon-acceptance:v1
-TTY_MODE := $(shell tty -s && echo -t)
 
 cucumber:
-	docker run --rm $(TTY_MODE) -v $(PWD):/cukes -v $(PWD)/../summon:/cukes/bin/summon -w /cukes $(TEST_HARNESS) cucumber
+	docker run --rm -v $(PWD):/cukes -v $(PWD)/../summon:/cukes/bin/summon -w /cukes $(TEST_HARNESS) cucumber

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 # Platforms to build: https://golang.org/doc/install/source#environment
-PLATFORMS=(
+
+DEFAULT_PLATFORMS=(
   'darwin:amd64'     # MacOS
-  # 'dragonfly:amd64'  # Dragonfly https://www.dragonflybsd.org/
   'freebsd:amd64'
-  # 'linux:386'
   'linux:amd64'
   # 'linux:arm'
   # 'linux:arm64'
@@ -15,12 +14,14 @@ PLATFORMS=(
   # 'windows:386'
   'windows:amd64'
 )
+PLATFORMS="${1:-${DEFAULT_PLATFORMS[@]}}"  # override this with a positional argument, like 'linux:amd64'
+
 OUTPUT_DIR='output'
 
 echo "Creating summon binaries in $OUTPUT_DIR/"
 docker-compose build --pull summon-builder
 
-for platform in "${PLATFORMS[@]}"; do
+for platform in ${PLATFORMS}; do
   GOOS=${platform%%:*}
   GOARCH=${platform#*:}
 

--- a/package.sh
+++ b/package.sh
@@ -20,8 +20,15 @@ done
 
 popd
 
+shasum_binary=shasum
+shasum_args='-a256'
+if ! hash $shasum_binary 2>/dev/null; then
+  shasum_binary=sha256sum  # on alpine linux
+  shasum_args=''
+fi
+
 # # Make the checksums
 echo "==> Checksumming..."
 pushd output/dist
-shasum -a256 * > SHA256SUMS.txt
+$shasum_binary $shasum_args * > SHA256SUMS.txt
 popd


### PR DESCRIPTION
This PR adds a public GitLab CI pipeline, using shared runners. Since summon is an open source project, we should build it in the open. We can continue to build in Jenkins as well. This is our first GitLab pipeline, and meant to be an example for other projects.

To set this up, I mirrored this repo to GitLab following these instructions: https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html#connect-manually. If you set it up the easy/default way mirroring seems to only run once an hour, not very helpful for CI.
I used a personal access token to set this up.

repo: https://gitlab.com/cyberark/summon
pipeline: https://gitlab.com/cyberark/summon/pipelines

I also added a couple badges to the README.

A few followups to think about:
- We should update github_hooks to create this gitlab webhook. Currently it will wipe it out when it runs.
- Access token is currently my personal one. If we want to scale this we should probably create a robot GitLab user we can attach tokens to, similar to `conjur-jenkins` user in Jenkins. This makes automation easier and more secure.
