### PR TITLE
Adding `-I, --ignore-all` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ the secrets stored in temp files and in the Python process environment are gone.
 
     This flag can be useful for when you have secrets that you don't need access to for development. For example API keys for monitoring tools. This flag can be used multiple times.
 
+* `-I, --ignore-all` A boolean to ignore any missing secret paths
+
+    This flag can be useful when the underlying system that's going to be using the values implements defaults. For example, when using summon as a bridge to [confd](https://github.com/kelseyhightower/confd).
+
 * `-e, --environment` Specify section (environment) to parse from secret YAML
 
     This flag specifies which specific environment/section to parse from the secrets YAML file (or string). In addition, it will also enable the usage of a `common` (or `default`) section which will be inherited by other sections/environments. In other words, if your `secrets.yaml` looks something like this:

--- a/command/action.go
+++ b/command/action.go
@@ -20,6 +20,7 @@ type ActionConfig struct {
 	YamlInline  string
 	Subs        map[string]string
 	Ignores     []string
+	IgnoreAll   bool
 	Environment string
 }
 
@@ -44,6 +45,7 @@ var Action = func(c *cli.Context) {
 		Filepath:    c.String("f"),
 		YamlInline:  c.String("yaml"),
 		Ignores:     c.StringSlice("ignore"),
+		IgnoreAll:   c.Bool("ignore-all"),
 		Subs:        convertSubsToMap(c.StringSlice("D")),
 	})
 
@@ -117,6 +119,10 @@ EnvLoop:
 		if envvar.error == nil {
 			env = append(env, envvar.string)
 		} else {
+			if ac.IgnoreAll {
+				continue EnvLoop
+			}
+
 			for i := range ac.Ignores {
 				if ac.Ignores[i] == envvar.string {
 					continue EnvLoop

--- a/command/action_test.go
+++ b/command/action_test.go
@@ -71,6 +71,26 @@ func TestRunAction(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(output, ShouldEqual, "mysecret\n")
 		})
+
+		Convey("Errors when fetching keys don't return error if ignore-all is true", func() {
+			var err error
+
+			output := captureStdout(func() {
+				err = runAction(&ActionConfig{
+					Args:       []string{"printenv", "MYVAR"},
+					Provider:   providerPath,
+					Filepath:   "",
+					YamlInline: "{MYVAR: !var test, ERR: !var error}",
+					Subs:       map[string]string{},
+					Ignores:    []string{},
+					IgnoreAll:  true,
+				})
+
+			})
+
+			So(err, ShouldBeNil)
+			So(output, ShouldEqual, "mysecret\n")
+		})
 	})
 }
 

--- a/command/flags.go
+++ b/command/flags.go
@@ -30,6 +30,10 @@ var Flags = []cli.Flag{
 	cli.StringSliceFlag{
 		Name:  "ignore, i",
 		Value: &cli.StringSlice{},
-		Usage: "Ignore the specified key if is isn't accessible or doesn’t exist",
+		Usage: "Ignore the specified key if is isn't accessible or doesn't exist",
+	},
+	cli.BoolFlag{
+		Name:  "ignore-all, I",
+		Usage: "Ignore inaccessible or missing keys",
 	},
 }


### PR DESCRIPTION
I'm currently using a wrapper to parse the secrets.yaml and generate a list for the `-i` flag. It would be really awesome if `summon` supported `--ignore-all` so I added it in this PR. I had a little trouble getting the tests to run, but I was able to test this by building the binary.

Feedback welcome!

Cheers!