### PR TITLE
88 execve windows bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Windows subprocess loading is again run with exec.Command. Closes[#88](https://github.com/cyberark/summon/issues/88).
+### Changed
+- Windows detection of 'Program Files' folder improved.
 
 ## [v0.6.9](https://github.com/cyberark/summon/releases/tag/v0.6.9) - 2018-12-07
 ### Changed

--- a/internal/command/subcommand_default.go
+++ b/internal/command/subcommand_default.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package command
 
 import (

--- a/internal/command/subcommand_windows.go
+++ b/internal/command/subcommand_windows.go
@@ -1,0 +1,50 @@
+// +build windows
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// runSubcommand executes a command with arguments in the context
+// of an environment populated with secret values.
+// XXX: Since Windows doesn't do fork/exec, we have to run the child
+//      process the old-fashioned parent-child relationship and shuffle
+//      the signals around.
+func runSubcommand(command []string, env []string) error {
+	binary, lookupErr := exec.LookPath(command[0])
+	if lookupErr != nil {
+		return lookupErr
+	}
+
+	runner := exec.Command(binary, command[1:]...)
+	runner.Stdin = os.Stdin
+	runner.Stdout = os.Stdout
+	runner.Stderr = os.Stderr
+	runner.Env = env
+
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel)
+
+	if startErr := runner.Start(); startErr != nil {
+		return startErr
+	}
+
+	// Forward all signals to the child process
+	go func() {
+		for {
+			receivedSignal := <-signalChannel
+			runner.Process.Signal(receivedSignal)
+		}
+	}()
+
+	if waitErr := runner.Wait(); waitErr != nil {
+		runner.Process.Signal(syscall.SIGKILL)
+		return waitErr
+	}
+
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -82,9 +82,14 @@ func expandPath(provider string) string {
 
 func getDefaultPath() string {
 	if runtime.GOOS == "windows" {
-		//No way to use SHGetKnownFolderPath(FOLDERID_ProgramFilesX64, ...)
-		//Hardcoding should be fine for now since SUMMON_PROVIDER and -p are available
-		return "C:\\Program Files\\Cyberark Conjur\\Summon\\Providers"
+		// Try to get the appropriate "Program Files" directory but if one doesn't
+		// exist, use a hardcoded value we think should be right.
+		program_files_dir := os.Getenv("ProgramW6432")
+		if program_files_dir == "" {
+			program_files_dir = path.Join("C:", "Program Files")
+		}
+
+		return path.Join(program_files_dir, "Cyberark Conjur", "Summon", "Providers")
 	} else {
 		return "/usr/local/lib/summon"
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"strings"
 	"runtime"
+	"strings"
 )
 
 var DefaultPath = getDefaultPath()


### PR DESCRIPTION
### Fixed
- Windows subprocess loading is again run with exec.Command. Closes[#88](https://github.com/cyberark/summon/issues/88).
### Changed
- Windows detection of 'Program Files' folder improved.

Connected to #88 