### PR TITLE
Fix documented provider search path

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -8,7 +8,8 @@ Searches for a provider in this order:
 
 1. `providerArg`, passed in via CLI
 2. Environment variable `SUMMON_PROVIDER`
-3. Executable in `/usr/libexec/summon/`.
+3. Executable in `/usr/local/lib/summon`
+(or `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows).
 
 `func Call(provider, specPath string) (string, error)`
 


### PR DESCRIPTION
Our documentation was not correct in the docs.