### PR TITLE
Upgrade pinned version of bundler to 2.0.2

### DIFF
--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -35,4 +35,4 @@ DEPENDENCIES
   aruba
 
 BUNDLED WITH
-   1.10.6
+   2.0.2


### PR DESCRIPTION
This should make the acceptance tests pass again. Upstream does not
provide bundler v1 by default anymore.

Connected to #109