### PR TITLE
Fix broken links and add gitleaks config

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,221 @@
+title = "summon gitleaks config"
+
+# You can configure gitleaks what to search for and what to whitelist.
+# The output you are seeing here is the default gitleaks config. If GITLEAKS_CONFIG environment variable
+# is set, gitleaks will load configurations from that path. If option --config-path is set, gitleaks will load
+# configurations from that path. Gitleaks does not whitelist anything by default.
+# - https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf
+# - https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
+[[rules]]
+description = "AWS Client ID"
+regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+tags = ["key", "AWS"]
+
+[[rules]]
+description = "AWS Secret Key"
+regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
+tags = ["key", "AWS"]
+
+[[rules]]
+description = "AWS MWS key"
+regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+tags = ["key", "AWS", "MWS"]
+
+[[rules]]
+description = "PKCS8"
+regex = '''-----BEGIN PRIVATE KEY-----'''
+tags = ["key", "PKCS8"]
+
+[[rules]]
+description = "RSA"
+regex = '''-----BEGIN RSA PRIVATE KEY-----'''
+tags = ["key", "RSA"]
+
+[[rules]]
+description = "SSH"
+regex = '''-----BEGIN OPENSSH PRIVATE KEY-----'''
+tags = ["key", "SSH"]
+
+[[rules]]
+description = "PGP"
+regex = '''-----BEGIN PGP PRIVATE KEY BLOCK-----'''
+tags = ["key", "PGP"]
+
+[[rules]]
+description = "Facebook Secret Key"
+regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+tags = ["key", "Facebook"]
+
+[[rules]]
+description = "Facebook Client ID"
+regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+tags = ["key", "Facebook"]
+
+[[rules]]
+description = "Facebook access token"
+regex = '''EAACEdEose0cBA[0-9A-Za-z]+'''
+tags = ["key", "Facebook"]
+
+[[rules]]
+description = "Twitter Secret Key"
+regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{35,44}['\"]'''
+tags = ["key", "Twitter"]
+
+[[rules]]
+description = "Twitter Client ID"
+regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{18,25}['\"]'''
+tags = ["client", "Twitter"]
+
+[[rules]]
+description = "Github"
+regex = '''(?i)github(.{0,20})?(?-i)['\"][0-9a-zA-Z]{35,40}['\"]'''
+tags = ["key", "Github"]
+
+[[rules]]
+description = "LinkedIn Client ID"
+regex = '''(?i)linkedin(.{0,20})?(?-i)['\"][0-9a-z]{12}['\"]'''
+tags = ["client", "Twitter"]
+
+[[rules]]
+description = "LinkedIn Secret Key"
+regex = '''(?i)linkedin(.{0,20})?['\"][0-9a-z]{16}['\"]'''
+tags = ["secret", "Twitter"]
+
+[[rules]]
+description = "Slack"
+regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+tags = ["key", "Slack"]
+
+[[rules]]
+description = "EC"
+regex = '''-----BEGIN EC PRIVATE KEY-----'''
+tags = ["key", "EC"]
+
+[[rules]]
+description = "Generic API key"
+regex = '''(?i)api_key(.{0,20})?['|"][0-9a-zA-Z]{32,45}['|"]'''
+tags = ["key", "API", "generic"]
+
+[[rules]]
+description = "Generic Secret"
+regex = '''(?i)secret(.{0,20})?['|"][0-9a-zA-Z]{32,45}['|"]'''
+tags = ["key", "Secret", "generic"]
+
+[[rules]]
+description = "Google API key"
+regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+tags = ["key", "Google"]
+
+[[rules]]
+description = "Google Cloud Platform API key"
+regex = '''(?i)(google|gcp|youtube|drive|yt)(.{0,20})?['\"][AIza[0-9a-z\\-_]{35}]['\"]'''
+tags = ["key", "Google", "GCP"]
+
+[[rules]]
+description = "Google OAuth"
+regex = '''(?i)(google|gcp|auth)(.{0,20})?['"][0-9]+-[0-9a-z_]{32}\.apps\.googleusercontent\.com['"]'''
+tags = ["key", "Google", "OAuth"]
+
+[[rules]]
+description = "Google OAuth access token"
+regex = '''ya29\.[0-9A-Za-z\-_]+'''
+tags = ["key", "Google", "OAuth"]
+
+[[rules]]
+description = "Heroku API key"
+regex = '''(?i)heroku(.{0,20})?['"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"]'''
+tags = ["key", "Heroku"]
+
+[[rules]]
+description = "MailChimp API key"
+regex = '''(?i)(mailchimp|mc)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]'''
+tags = ["key", "Mailchimp"]
+
+[[rules]]
+description = "Mailgun API key"
+regex = '''(?i)(mailgun|mg)(.{0,20})?['"][0-9a-z]{32}['"]'''
+tags = ["key", "Mailgun"]
+
+[[rules]]
+description = "Password in URL"
+regex = '''[a-zA-Z]{3,10}:\/\/[^\/\s:@]{3,20}:[^\/\s:@]{3,20}@.{1,100}\/?.?'''
+tags = ["key", "URL", "generic"]
+
+[[rules]]
+description = "PayPal Braintree access token"
+regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
+tags = ["key", "Paypal"]
+
+[[rules]]
+description = "Picatic API key"
+regex = '''sk_live_[0-9a-z]{32}'''
+tags = ["key", "Picatic"]
+
+[[rules]]
+description = "Slack Webhook"
+regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+tags = ["key", "slack"]
+
+[[rules]]
+description = "Stripe API key"
+regex = '''(?i)stripe(.{0,20})?['\"][sk|rk]_live_[0-9a-zA-Z]{24}'''
+tags = ["key", "Stripe"]
+
+[[rules]]
+description = "Square access token"
+regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
+tags = ["key", "square"]
+
+[[rules]]
+description = "Square OAuth secret"
+regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+tags = ["key", "square"]
+
+[[rules]]
+description = "Twilio API key"
+regex = '''(?i)twilio(.{0,20})?['\"][0-9a-f]{32}['\"]'''
+tags = ["key", "twilio"]
+
+[whitelist]
+files = [
+  ".gitleaks.toml"
+]
+
+#commits = [
+#  "whitelisted-commit1",
+#  "whitelisted-commit2",
+#]
+#repos = [
+#	"whitelisted-repo"
+#]
+
+# Additional Examples
+
+# [[rules]]
+# description = "Generic Key"
+# regex = '''(?i)key(.{0,6})?(:|=|=>|:=)'''
+# entropies = [
+#     "4.1-4.3",
+#     "5.5-6.3",
+# ]
+# entropyROI = "line"
+# filetypes = [".go", ".py", ".c"]
+# tags = ["key"]
+# severity = "8"
+#
+#
+# [[rules]]
+# description = "Generic Key"
+# regex = '''(?i)key(.{0,6})?(:|=|=>|:=)'''
+# entropies = ["4.1-4.3"]
+# filetypes = [".gee"]
+# entropyROI = "line"
+# tags = ["key"]
+# severity = "medium"
+
+# [[rules]]
+# description = "Any pem file"
+# filetypes = [".key"]
+# tags = ["pem"]
+# severity = "high"
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -180,6 +180,15 @@ tags = ["key", "twilio"]
 files = [
   ".gitleaks.toml"
 ]
+regexes= [
+  "AKIAIOSFODNN7EXAMPLE"
+]
+commits = [
+  "923689f11e8636d5de9cc33f8eb99bf951c6b9b5",
+  "95b468ac083a093b5b2779438ba6bf15163178da",
+  "662186377423d00c77781f6459a08f70c3c30ceb",
+  "9c098b504d5d6d5e5b157f129e450131bce48041"
+]
 
 #commits = [
 #  "whitelisted-commit1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added gitleaks configuration
+
+### Fixed
+- Fixed broken website links
+
 ## [v0.7.0](https://github.com/cyberark/summon/releases/tag/v0.7.0) - 2019-07-11
 ### Changed
 - Updated yaml.v1 dependency to [yaml.v3](gopkg.in/yaml.v3) in part to address

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -81,8 +81,6 @@ Here are some specific examples of how you can use summon with your current tool
 
 * [Docker](http://cyberark.github.io/summon/docker.html)
 
-Let us know what tools you would like us to cover next at [oss@conjur.net](mailto:oss@conjur.net).
-
 <h1 id="providers">providers</h1>
 
 * [AWS S3](https://github.com/conjurinc/summon-s3)

--- a/docs/_includes/docker.md
+++ b/docs/_includes/docker.md
@@ -124,4 +124,3 @@ AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ---
 
 We hope Summon makes it easier for you to work with Docker and secrets. If you have an idea for a new feature or notice a problem, please don't hesitate to [open an issue or pull request on GitHub](https://github.com/cyberark/summon).
-You can also send any feedback to [oss@conjur.net](mailto:oss@conjur.net).

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -36,7 +36,7 @@
     <a href="https://github.com/cyberark/summon/releases" class="btn">Download</a>
     <a href="http://cyberark.github.io/summon/#providers" class="btn">Providers</a>
     <div id="byConjur">
-      <a href="https://www.conjur.net?utm_campaign=summon&utm_source=GitHub">
+      <a href="https://www.conjur.org?utm_campaign=summon&utm_source=GitHub">
         <span class="project-tagline">brewed by</span>
         <img src="//i.imgur.com/08rC50B.png"/>
       </a>


### PR DESCRIPTION
- Update the website documentation to fix broken links to point to conjur.org instead of the (old) conjur.net
- Add a [gitleaks config file](.gitleaks.toml) to the project
- Updated the gitleaks config to ignore the (invalid) doc / test RSA / AWS keys

There are still some broken links in the docs that point to the docker examples, and I filed a follow-up issue for that in #112.