### PR TITLE
Add Buildkite to list of "use summon with your current tools" examples

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -80,6 +80,7 @@ Summon is meant to work with your existing toolchains. If you can access environ
 Here are some specific examples of how you can use summon with your current tools.
 
 * [Docker](http://cyberark.github.io/summon/docker.html)
+* [Buildkite](https://github.com/angaza/summon-buildkite-plugin)
 
 <h1 id="providers">providers</h1>
 


### PR DESCRIPTION
[Buildkite](https://buildkite.com/) is a popular CI/CD tool. Summon can be integrated with Buildkite to improve secrets handling. This PR adds an example of making that integration work. (It [sounded like](https://cyberark.github.io/summon/#providers) this kind of addition to the docs would be welcome.)