### PR TITLE
Add ability to handle empty variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Added ability to support empty variables [#124](https://github.com/cyberark/summon/issues/124)
+
+### Added
+- Added better errors for unkown tags found in the yaml
+
 ## [v0.8.0](https://github.com/cyberark/summon/releases/tag/v0.8.0) - 2019-09-20
 
 ### Changed

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -63,6 +63,25 @@ BOOL: true`
 		})
 	})
 
+	Convey("Given an empty variable in secrets.yml", t, func() {
+		testEnv := "TestEnvironment"
+		input := `TestEnvironment:
+  SOME_VAR1: !var $env/sentry/api_key
+  EMPTY_VAR:
+  SOME_VAR2: !var:file $env/aws/ec2/private_key`
+
+		Convey("It should correctly parse the file", func() {
+			parsed, err := ParseFromString(input, testEnv, map[string]string{"env": "prod"})
+			So(err, ShouldBeNil)
+
+			spec := parsed["EMPTY_VAR"]
+			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "")
+		})
+	})
+
 	Convey("Given a string with environment in secrets.yml format", t, func() {
 		testEnv := "TestEnvironment"
 		input := `TestEnvironment:


### PR DESCRIPTION
Even though this is not quite something we would normally expect, there
is no good reason why we should prevent it. The change makes any
variables set with no tags set be interpreted as literals. As an
addition we also propagate errors in parsing better that were just
indicated by a non-helpful message before.

Connected to #124