### PR TITLE
Add ability so set a default value for a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added better errors for unkown tags found in the yaml
+- Added ability to set a default variable value with `default='<value>'` tag [#38](https://github.com/cyberark/summon/issues/38)
 
 ## [v0.8.0](https://github.com/cyberark/summon/releases/tag/v0.8.0) - 2019-09-20
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@
 
 It provides an interface for
 
-* Reading a **secrets.yml** file
+* Reading a `secrets.yml` file
 * Fetching secrets from a trusted store
 * Exporting secret values to a sub-process environment
 
 ## Install
 
-Note installing **summon** alone is not sufficient; you need to also install a [provider of your choice](http://cyberark.github.io/summon/#providers) before it's ready for use.
+Note installing `summon` alone is not sufficient; you need to also install
+a [provider of your choice](http://cyberark.github.io/summon/#providers) before it's ready for use.
 
 Pre-built binaries and packages are available from GitHub releases
 [here](https://github.com/cyberark/summon/releases).
@@ -89,6 +90,47 @@ summon python listEC2.py
 
 `python listEC2.py` is the command that summon wraps. Once the Python program exits,
 the secrets stored in temp files and in the Python process environment are gone.
+
+### `secrets.yml` Flags
+
+Currently, you can define how the value of a variable will be processed using YAML tags. Multiple
+tags can be defined per variable by spearating them with `:`. By default, values are resolved
+as literal values.
+- `!file`: Resolves the variable value, places it into a tempfile, and returns the path to that
+file.
+- `!var`: Resolves the value as a variable ID from the provider.
+- `!str`: Resolves the value as a literal (default).
+- `!default='<value>'`: If the value resolution returns an empty string, use this literal value
+instead for it.
+
+**Examples**
+```yaml
+# Resolved summon-env string (eg. `production/sentry/api_key`) is sent to the provider
+# and the value returned is saved in the variable.
+API_KEY: !var $env/sentry/api_key
+
+# Resolved summon-env string (eg. `production/aws/ec2/private_key`) is sent to the provider.
+# The returned value is put into a tempfile and the path for that file is saved in the
+# variable.
+API_KEY_PATH: !file:var $env/aws/ec2/private_key
+
+# Literal value `my content` is saved into a tempfile and the path for that file is saved
+# in the variable.
+SECRET_DATA: !file my content
+
+# Resolved summon-env string (eg. `production/sentry/api_user`) is sent to the provider.
+# The returned value is put into a tempfile. If the value from the provider is an empty
+# string then the default value (`admin`) is put into that tempfile. The path to that
+# tempfile is saved in the variable.
+API_USER: !var:default='admin':file $env/sentry/api_user
+```
+
+### Default values
+
+Default values can be set by using the `default='yourdefaultvalue'` as an addtional tag on the variable:
+```yaml
+VARIABLE_WITH_DEFAULT: !var:default='defaultvalue' path/to/variable
+```
 
 ### Flags
 

--- a/internal/command/action.go
+++ b/internal/command/action.go
@@ -107,6 +107,11 @@ func runAction(ac *ActionConfig) error {
 				value = spec.Path
 			}
 
+			// Set a default value if the provider didn't return one for the item
+			if value == "" && spec.DefaultValue != "" {
+				value = spec.DefaultValue
+			}
+
 			envvar := formatForEnv(key, value, spec, &tempFactory)
 			results <- Result{envvar, nil}
 			wg.Done()

--- a/secretsyml/secretsyml_test.go
+++ b/secretsyml/secretsyml_test.go
@@ -16,6 +16,8 @@ PRIVATE_KEY_FILE: !file:var $env/aws/ec2/private_key
 PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
 SOME_FILE: !file my content
 RAILS_ENV: $env
+DEFAULT_VAR: !var:default='defaultvalue':file $env/sentry/api_key
+DEFAULT_VAR2: !default='def' foo
 SOME_ESCAPING_VAR: FOO$$BAR
 FLOAT: 27.1111
 INT: 27
@@ -49,11 +51,28 @@ BOOL: true`
 
 			spec = parsed["SOME_ESCAPING_VAR"]
 			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsFile(), ShouldBeFalse)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "FOO$BAR")
 
+			spec = parsed["DEFAULT_VAR"]
+			So(spec.IsFile(), ShouldBeTrue)
+			So(spec.IsVar(), ShouldBeTrue)
+			So(spec.IsLiteral(), ShouldBeFalse)
+			So(spec.Path, ShouldEqual, "prod/sentry/api_key")
+			So(spec.DefaultValue, ShouldEqual, "defaultvalue")
+
+			spec = parsed["DEFAULT_VAR2"]
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "foo")
+			So(spec.DefaultValue, ShouldEqual, "def")
+
 			spec, found := parsed["FLOAT"]
 			So(found, ShouldBeTrue)
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsVar(), ShouldBeFalse)
 			So(spec.IsLiteral(), ShouldBeTrue)
 			So(spec.Path, ShouldEqual, "27.1111")
 
@@ -95,6 +114,7 @@ BOOL: true`
   PRIVATE_KEY_FILE: !file:var $env/aws/ec2/private_key
   PRIVATE_KEY_FILE2: !var:file $env/aws/ec2/private_key
   SOME_FILE: !file my content
+  DEFAULT_VAR: !default='def' $env/value
   RAILS_ENV: $env
   FLOAT: 27.1111
   INT: 27
@@ -121,6 +141,12 @@ BOOL: true`
 			So(spec.IsVar(), ShouldBeFalse)
 			So(spec.IsFile(), ShouldBeTrue)
 			So(spec.IsLiteral(), ShouldBeFalse)
+
+			spec = parsed["DEFAULT_VAR"]
+			So(spec.IsVar(), ShouldBeFalse)
+			So(spec.IsFile(), ShouldBeFalse)
+			So(spec.IsLiteral(), ShouldBeTrue)
+			So(spec.Path, ShouldEqual, "prod/value")
 
 			spec = parsed["RAILS_ENV"]
 			So(spec.IsVar(), ShouldBeFalse)
@@ -209,5 +235,4 @@ TestEnvironment:
 			So(spec.Path, ShouldEqual, "prod")
 		})
 	})
-
 }


### PR DESCRIPTION
This change adds the capability to set a default value of a variable in
a tag. If the value resolves to an empty value (but is not an error), we
set that variable to the one specified in `default='<value>'` tag.

Issue #38