### PR TITLE
Prepare for v0.8.1 release by bumping the version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.8.1] - 2020-03-02
 ### Changed
 - Added ability to support empty variables [#124](https://github.com/cyberark/summon/issues/124)
 
 ### Added
-- Added better errors for unkown tags found in the yaml
+- Added better errors for unknown tags found in the yaml
 - Added ability to set a default variable value with `default='<value>'` tag [#38](https://github.com/cyberark/summon/issues/38)
 
 ## [0.8.0] - 2019-09-20
@@ -151,7 +153,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cyberark/summon/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/cyberark/summon/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/cyberark/summon/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/cyberark/summon/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cyberark/summon/compare/v0.6.11...v0.7.0
 [0.6.11]: https://github.com/cyberark/summon/compare/v0.6.10...v0.6.11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,34 @@ To build versions for Linux, OSX and Windows:
 ```
 
 Binaries will be placed in `output/`.
+
+### Releasing
+
+The following checklist should be followed when creating a release:
+
+- [ ] Open a PR with the following changes for `master` branch and wait for it to be merged:
+  - [ ] Bump release version in [`pkg/summon/version.go`](pkg/summon/version.go).
+  - [ ] Bump version in [`CHANGELOG.md`](CHANGELOG.md).
+- [ ] Create a draft release:
+  - [ ] Create an [annotated tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_annotated_tags)
+of the merged commit with the name `v<version>` and push it to the repository.
+  - [ ] Using the GitHub UI, create a release using the tag created earlier as the starting point.
+  - [ ] Name the release the same as the tag.
+  - [ ] Include in the release notes all changes from CHANGELOG that are being released.
+- [ ] Attach the relevant assets to the release:
+  - [ ] [`Build`](./build) the release.
+  - [ ] Attach `dist/summon-darwin-amd64.tar.gz` to release.
+  - [ ] Attach `dist/summon-linux-amd64.tar.gz` to release.
+  - [ ] Attach `dist/summon-windows-amd64.tar.gz` to release.
+  - [ ] Attach `dist/summon.rpm` to release.
+  - [ ] Attach `dist/summon.deb` to release.
+  - [ ] Attach `dist/CHANGELOG.md` to release.
+  - [ ] Edit `dist/SHA256SUMS.txt` to include only the attached files above.
+  - [ ] Attach `dist/SHA256SUMS.txt` to the release.
+- [ ] Publish the release as a "pre-released".
+- [ ] TBD: Perform smoke tests of all attached files in release.
+- [ ] Publish the release as a regular release.
+- [ ] Update homebrew tools
+  - [ ] In [`cyberark/homebrew-tools`](https://github.com/cyberark/homebrew-tools) repo, update
+  the [`summon.rb` formula](https://github.com/cyberark/homebrew-tools/blob/master/summon.rb#L4-L6) with a PR.
+  - [ ] Once the PR is merged, verify that summon works by smoke testing it on OSX.

--- a/pkg/summon/version.go
+++ b/pkg/summon/version.go
@@ -1,4 +1,4 @@
 package summon
 
 // VERSION is the version of summon
-const VERSION = "0.8.0"
+const VERSION = "0.8.1"


### PR DESCRIPTION
We are preparing to release the current bundle of features as 0.8.1 so
we incremented the version in both version.go and the changelog.