### PR TITLE
Fix brew templates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ checksum:
 brews:
   - description: CLI that provides on-demand secrets access for common DevOps tools.
     homepage: https://github.com/cyberark/summon
-    url_template: https://github.com/cyberark/summon/releases/download/v{{.Version}}/summon-darwin-amd64.tar.gz
+    url_template: https://github.com/cyberark/summon/releases/download/v{{.Version}}/summon-{{ tolower .Os }}-{{ tolower .Arch }}.tar.gz
     install: |
       bin.install "summon"
     test: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,6 @@ of the merged commit with the name `v<version>` and push it to the repository.
 - [ ] Publish the release as a regular release.
 - [ ] Update homebrew tools
   - [ ] In [`cyberark/homebrew-tools`](https://github.com/cyberark/homebrew-tools) repo, update
-  the [`summon.rb` formula](https://github.com/cyberark/homebrew-tools/blob/master/summon.rb#L4-L6) with a PR.
+  the [`summon.rb` formula](https://github.com/cyberark/homebrew-tools/blob/master/summon.rb#L4-L6) with a PR
+  using the file `dist/summon.rb`.
   - [ ] Once the PR is merged, verify that summon works by smoke testing it on OSX.


### PR DESCRIPTION
Old URLs were statically forced to use "darwin" as the OS so now they
are dynamic. We now also dynamically specify the arch for the brew URL
links.