### PR TITLE
Fixed Goreleaser nfpm parameter usage

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ brews:
     skip_upload: true
 
 nfpms:
-  - name_template: "{{.ProjectName}}"
+  - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"
     vendor: CyberArk
     homepage: https://github.com/cyberark/summon
     maintainer: Dustin Collins <dustin.collins@cyberark.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ of the merged commit with the name `v<version>` and push it to the repository.
   - [ ] Attach `dist/summon-darwin-amd64.tar.gz` to release.
   - [ ] Attach `dist/summon-linux-amd64.tar.gz` to release.
   - [ ] Attach `dist/summon-windows-amd64.tar.gz` to release.
-  - [ ] Attach `dist/summon.rpm` to release.
-  - [ ] Attach `dist/summon.deb` to release.
+  - [ ] Attach `dist/summon_v*.rpm` to release.
+  - [ ] Attach `dist/summon_v*.deb` to release.
   - [ ] Attach `dist/CHANGELOG.md` to release.
   - [ ] Edit `dist/SHA256SUMS.txt` to include only the attached files above.
   - [ ] Attach `dist/SHA256SUMS.txt` to the release.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ brew install summon
 ### Linux (Debian and Red Hat flavors)
 
 `deb` and `rpm` files are attached to new releases.
-These can be installed with `dpkg -i summon.deb` and
-`rpm -ivh summon.rpm`, respectively.
+These can be installed with `dpkg -i summon_v*.deb` and
+`rpm -ivh summon_v*.rpm`, respectively.
 
 ### Auto Install
 


### PR DESCRIPTION
Old name_template is removed and has been replaced by
file_name_template so this commit updates it. We also now provide a
version and arch in the deb/rpm name since those are pretty valuable
pieces of info for an operator.

Fixes #145