### PR TITLE
112 broken docker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ junit.xml
 .vscode/
 main
 keychain
-secrets.yml
 .godeps
 vendor/
 Godeps/

--- a/docs/_includes/docker.md
+++ b/docs/_includes/docker.md
@@ -2,60 +2,77 @@
 
 Docker works best when you follow the 12-factor suggestion of storing your
 config [in the environment](http://12factor.net/config). Your images are then
-immutable artifacts that you can move through environments. This works great for public config (DNS names, database ports, log levels, etc), but what
-about sensitive config (database passwords, API tokens, etc)? You can bake credentials into your images, but now you have to lock down your images and rotation is difficult. You can repurpose tools like [consul](https://www.consul.io/) or [etcd](https://coreos.com/etcd/) to serve secrets, but they are not meant for passing around secrets.
+immutable artifacts that you can move through environments. This works great for
+public config (DNS names, database ports, log levels, etc), but what
+about sensitive config (database passwords, API tokens, etc)? You can bake
+credentials into your images, but now you have to lock down your images and
+rotation is difficult. You can repurpose tools like [consul](https://www.consul.io/)
+or [etcd](https://coreos.com/etcd/) to serve secrets, but they are not meant for
+passing around secrets.
 
-Using Summon with Docker means that the secrets your application
-needs are declared in `secrets.yml` and can be checked into source control right next to your Dockerfile. Since Summon has pluggable providers, you aren't locked into any one solution for managing your secrets.
+Using Summon with Docker means that the secrets your application needs are declared
+in `secrets.yml` and can be checked into source control right next to your Dockerfile.
+Since Summon has pluggable providers, you aren't locked into any one solution for
+managing your secrets.
 
-Summon makes it easy to inject secrets as environment variables into your Docker containers by taking advantage of Docker's `--env-file` argument. This is done on-demand by using the variable `@SUMMONENVFILE` in the arguments of the process you are running with Summon. This variable points to a memory-mapped file containing the variables and values from secrets.yml in VAR=VAL format.
+Summon makes it easy to inject secrets as environment variables into your Docker
+containers by taking advantage of Docker's `--env-file` argument. This is done
+on-demand by using the variable `@SUMMONENVFILE` in the arguments of the process
+you are running with Summon. This variable points to a memory-mapped file containing
+the variables and values from secrets.yml in VAR=VAL format.
 
 ```sh
-$ summon -p ring.py -D env=dev docker run --env-file @SUMMONENVFILE deployer
+$ summon -p keyring.py -D env=dev docker run --env-file @SUMMONENVFILE deployer
 Checking credentials
 Deploying application
 ```
 
 ## Example
 
-Let's say we have a deploy script that needs to access our application servers on AWS and pull the latest version of our code. It should record the outcome of the deployment to a datastore. To deploy, then, we need AWS keys and a MongoDB password.
+Let's say we have a deploy script that needs to access our application servers on
+AWS and pull the latest version of our code. It should record the outcome of the
+deployment to a datastore. To deploy, then, we need AWS keys and a MongoDB password.
 
-### 1. Clone the example repository
+### 1. Clone the Summon repository
 
-The repository for this example is at [github.com/conjurdemos/summon-docker-tutorial](https://github.com/conjurdemos/summon-docker-tutorial). Clone that and we'll
-get started.
+This example is stored in the Summon repository in the `examples` folder. To get
+started, we'll need to clone the Summon repository and navigate to the example folder.
 
 ```sh
-$ git clone https://github.com/conjurdemos/summon-docker-tutorial.git
-$ cd summon-docker-tutorial
+$ git clone https://github.com/cyberark/summon.git
+$ cd summon/examples/docker/
 ```
 
-There are 3 key files in this repository.
+There are 3 key files in this directory.
 
 **secrets.yml**
 
-This is the file that Summon will read, a mapping of environment variables to
-the name of secrets we want to fetch. Secrets *are* dependencies so we should be able to track them in source control. `$env` is a variable that we will supply at runtime with summon's `-D` flag. This means that we can use one `secrets.yml` file for all environments, swapping out `$env` as needed.
+This is the file that Summon will read, and it contains a mapping of environment
+variables to the name of secrets we want to fetch. Secrets *are* dependencies so
+we should be able to track them in source control. `$env` is a variable that we
+will supply at runtime with Summon's `-D` flag. This means that we can use one
+`secrets.yml` file for all environments, swapping out `$env` as needed.
 
-<script src="http://gist-it.appspot.com/github/conjurdemos/summon-docker-tutorial/blob/master/secrets.yml"></script>
+<script src="http://gist-it.appspot.com/github/cyberark/summon/blob/master/examples/docker/secrets.yml"></script>
 
 **deploy.py**
 
 A stubbed-out deploy script. It checks that you have the proper credentials
 before attempting a deploy.
 
-<script src="http://gist-it.appspot.com/github/conjurdemos/summon-docker-tutorial/blob/master/deploy.py"></script>
+<script src="http://gist-it.appspot.com/github/cyberark/summon/blob/master/examples/docker/deploy.py"></script>
 
 **Dockerfile**
 
-Inherits from the [offical Python Docker image](https://registry.hub.docker.com/_/python/) and runs the deploy script. `requirements.txt` is empty, but if
-it wasn't it would pip install your dependencies.
+Inherits from the [offical Python Docker image](https://registry.hub.docker.com/_/python/)
+and runs the deploy script.
 
-<script src="http://gist-it.appspot.com/github/conjurdemos/summon-docker-tutorial/blob/master/Dockerfile"></script>
+<script src="http://gist-it.appspot.com/github/cyberark/summon/blob/master/examples/docker/Dockerfile"></script>
 
 ### 2. Build and run the container
 
-*Note: [Install Docker](https://docs.docker.com/installation/) if you don't already have it on your system.*
+**Note:** [Install Docker](https://docs.docker.com/get-docker/) if you don't already
+have it on your system.
 
 Now we can build a Docker image and run our deploy script inside it.
 
@@ -69,32 +86,28 @@ AWS_SECRET_ACCESS_KEY not available!
 MONGODB_PASSWORD not available!
 ```
 
-Our deploy script is checking for available credentials. None are available, so it doesn't run the deploy.
+Our deploy script is checking for available credentials. None are available, so it
+doesn't run the deploy.
 
 ### 3. Install Summon and the keyring provider
 
-To install summon, either use the install script
+Install Summon following the instructions in the [README](https://github.com/cyberark/summon/#install).
 
-```sh
-$ curl -sSL https://raw.githubusercontent.com/cyberark/summon/master/install.sh | bash
-```
-
-or [download the latest release](https://github.com/cyberark/summon/releases/latest) and unzip it into your `PATH`.
-
-We'll use the [keyring provider](https://github.com/conjurinc/summon-keyring) for this tutorial since it is cross-platform and doesn't require communication with a secrets server.
-
-```sh
-$ pip install keyring # dependency of the provider
-$ mkdir -p /usr/libexec/summon
-$ sudo curl -sSL -o /usr/libexec/summon/ring.py https://raw.githubusercontent.com/conjurinc/summon-keyring/master/ring.py
-$ sudo chmod a+x /usr/libexec/summon/ring.py
-```
+We'll use the [keyring provider](https://github.com/conjurinc/summon-keyring) for
+this tutorial since it is cross-platform and doesn't require communication with a
+secrets server. Install it following its [README instructions](https://github.com/cyberark/summon-keyring/#install).
 
 ### 4. Run the container with Summon
 
-We want to provide our credentials to the container with Summon. Since we're using the keychain provider, we'll put those secrets in our keychain. The keychain provider [supports many implementations](https://bitbucket.org/kang/python-keyring-lib/src/default/keyring/backends/). We'll use the OSX keychain for this example - modify the commands depending on the keychain you use.
+We want to provide our credentials to the container with Summon. Since we're using
+the keychain provider, we'll put those secrets in our keychain. The keychain provider
+is extensible and [supports many keyring implementations](https://pypi.org/project/keyring/)
+out of the box. We'll use the OSX keychain for this example - modify the commands
+depending on the keychain you use.
 
-Remember the `$env` variable in our `secrets.yml`? We'll use 'dev' for this tutorial, since we'd probably not use the keyring provider in production. Load the secrets into your keychain. We'll use "summon" as the service name.
+Remember the `$env` variable in our `secrets.yml`? We'll use 'dev' for this tutorial,
+since we'd probably not use the keyring provider in production. Load the secrets into
+your keychain. We'll use "summon" as the service name.
 
 ```sh
 $ security add-generic-password -s "summon" -a "dev/aws_access_key_id" -w "AKIAIOSFODNN7EXAMPLE"
@@ -105,17 +118,18 @@ $ security add-generic-password -s "summon" -a "dev/mongodb_password" -w "blom0e
 Now we can run Docker with Summon to provide our credentials.
 
 ```sh
-$ summon -p ring.py -D env=dev docker run --env-file @SUMMONENVFILE deployer
+$ summon -p keyring.py -D env=dev docker run --env-file @SUMMONENVFILE deployer
 Checking credentials
 Deploying application
 ```
 
-Summon parsed `secrets.yml`, used the keychain provider to fetch values from our keychain and made them available to Docker as `@SUMMONENVFILE`. Neat huh?
+Summon parsed `secrets.yml`, used the keychain provider to fetch values from our
+keychain and made them available to Docker as `@SUMMONENVFILE`. Neat huh?
 
 You can also view the value of `@SUMMONENVFILE` by simply `cat`ing it.
 
 ```sh
-$ summon -p ring.py -D env=dev cat @SUMMONENVFILE
+$ summon -p keyring.py -D env=dev cat @SUMMONENVFILE
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 MONGODB_PASSWORD=blom0ey4hOj3We
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -123,4 +137,6 @@ AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 ---
 
-We hope Summon makes it easier for you to work with Docker and secrets. If you have an idea for a new feature or notice a problem, please don't hesitate to [open an issue or pull request on GitHub](https://github.com/cyberark/summon).
+We hope Summon makes it easier for you to work with Docker and secrets. If you have
+an idea for a new feature or notice a problem, please don't hesitate to
+[open an issue or pull request on GitHub](https://github.com/cyberark/summon).

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:alpine3.10
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY deploy.py /src/
+
+ENTRYPOINT [ "python", "deploy.py" ]
+

--- a/examples/docker/deploy.py
+++ b/examples/docker/deploy.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+print("Checking credentials")
+
+haveSecrets = True
+
+secretKeys = [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "MONGODB_PASSWORD" ]
+
+for key in secretKeys:
+  if key not in os.environ:
+    print("%s not available!" % key)
+    haveSecrets = False
+
+if not haveSecrets:
+  sys.exit()
+
+print("Deploying application")
+
+"""
+Insert deployment script steps here!
+"""

--- a/examples/docker/secrets.yml
+++ b/examples/docker/secrets.yml
@@ -1,0 +1,3 @@
+AWS_ACCESS_KEY_ID: !var $env/aws_access_key_id
+AWS_SECRET_ACCESS_KEY: !var $env/mongodb_password
+MONGODB_PASSWORD: !var $env/aws_secret_access_key


### PR DESCRIPTION
Fixes #112 

This PR adds some missing functionality from the Docker tutorial so that a user can run through it e2e. It also adds an `examples` folder to the project following the [Go layout standards](https://github.com/golang-standards/project-layout) that may be a useful place to encourage contributions of other example flows that the docs can refer to.