### PR TITLE
Add ability to produce Solaris binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
   - -tags=netgo
   goos:
   - darwin  # MacOS
+  - solaris
   - windows
   goarch:
   - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [0.8.3] - 2020-08-28
+## [0.8.3] - 2020-09-25
+
+### Added
+- Added preliminary support for building Solaris binaries.
+  [cyberark/summon#173](https://github.com/cyberark/summon/issues/173)
+
 ### Fixed
 - Use of a path for a provider via `--provider` CLI flag or `SUMMON_PROVIDER` env
   variable on Windows with `\` as path separators now correctly works.


### PR DESCRIPTION
We had a request to enable our building of Solaris binaries and we can
do that relatively easily in preparation for 0.8.3 release.

### What ticket does this PR close?
Connected to #173 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation