### PR TITLE
Quote multi-line values in @SUMMONENVFILE

### DIFF
--- a/internal/command/action.go
+++ b/internal/command/action.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -199,9 +200,14 @@ func formatForEnv(key string, value string, spec secretsyml.SecretSpec, tempFact
 func joinEnv(env map[string]string) string {
 	var envs []string
 	for k, v := range env {
-		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+		if strings.Contains(v, "\n") {
+			keyEq := []byte(fmt.Sprintf("%s=", k))
+			envs = append(envs, string(strconv.AppendQuote(keyEq, v)))
+		} else {
+			envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+		}
 	}
-	
+
 	// Sort to ensure predictable results
 	sort.Strings(envs)
 

--- a/internal/command/action_test.go
+++ b/internal/command/action_test.go
@@ -81,8 +81,8 @@ func TestFormatForEnvString(t *testing.T) {
 
 func TestJoinEnv(t *testing.T) {
 	Convey("adds a trailing newline", t, func() {
-		result := joinEnv(map[string]string{"foo": "bar", "baz": "qux"})
-		So(result, ShouldEqual, "baz=qux\nfoo=bar\n")
+		result := joinEnv(map[string]string{"foo": "bar\nfoo", "baz": "qux"})
+		So(result, ShouldEqual, "baz=qux\nfoo=\"bar\\nfoo\"\n")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?
If a secret contains a multi-line value, `@SUMMONENVFILE` is not sourceable because the value must be quoted.
The PR changes way more thing then I expected, but it was needed due to the fact that the formatting is done the same way for environment variables and environment file.

### What ticket does this PR close?
Resolves #31 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation