### PR TITLE
Preliminary support for @SUMMONDOCKERARGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY go.mod go.sum ./
 
 RUN apk add --no-cache bash \
                        build-base \
+                       docker-cli \
                        git && \
     go mod download && \
     go get -u github.com/jstemmer/go-junit-report && \

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -5,7 +5,8 @@ RUN apk add --no-cache bash \
                        git \
                        libffi-dev \
                        ruby-bundler \
-                       ruby-dev
+                       ruby-dev \
+                       docker-cli
 
 # Install summon prerequisites
 WORKDIR /summon

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -2,11 +2,11 @@ FROM golang:1.13-alpine
 
 RUN apk add --no-cache bash \
                        build-base \
+                       docker-cli \
                        git \
                        libffi-dev \
                        ruby-bundler \
-                       ruby-dev \
-                       docker-cli
+                       ruby-dev
 
 # Install summon prerequisites
 WORKDIR /summon

--- a/docs/_includes/docker.md
+++ b/docs/_includes/docker.md
@@ -16,8 +16,66 @@ Since Summon has pluggable providers, you aren't locked into any one solution fo
 managing your secrets.
 
 Summon makes it easy to inject secrets as environment variables into your Docker
-containers by taking advantage of Docker's `--env-file` argument. This is done
-on-demand by using the variable `@SUMMONENVFILE` in the arguments of the process
+containers by taking advantage of Docker's CLI arguments (`--env-file` or, `--env` and `--volume`. There are two options available. It's possible to mix and match as you see fit.
+
+## --env and --volume arguments
+This is done on-demand by using the variable `@SUMMONDOCKERARGS` in the arguments of the process
+you are running with Summon. This variable is replaced by combinations of the Docker arguments `--env` and `--volume` such that the secrets injected by summon are passed into the Docker container. The `--volume` arguments allow memory-mapped temporary files from variables with the `!file` tag to be resolvable inside the container.
+
+**NOTE:** Using the `!file` tag with `@SUMMONDOCKERARGS` assumes that the Docker CLI is being run on the host that is used to create volume mounts to the container. For when this is not the case simply avoid using the `!file` tag, but be mindful that in that case you lose the benefits of memory-mapped temporary files.
+
+```bash
+$ summon -p keyring.py -D env=dev docker run @SUMMONDOCKERARGS deployer
+Checking credentials
+Deploying application
+```
+
+### Example
+The example below demonstrates the use @SUMMONDOCKERARGS. For the sake of brevity
+we use an inline `secrets.yml` and the `/bin/echo` provider. Some points to note:
+1. `summon` is
+invoking docker as the child process.
+2. `@SUMMONDOCKERARGS` is replaced with a combination of `--env` and `--volume`
+arguments.
+3. Variable `D` uses the `!file` tag and therefore is the only one that
+results in a `--volume` argument. The path to this variable inside the container
+is as it is on the host.
+
+```bash
+secretsyml='
+A: |-
+  A_value with
+  multiple lines
+B: B_value
+C: !var C_value
+D: !var:file D_value
+'
+
+# The substitution of @SUMMONDOCKERARGS the docker run command below results in
+# something of the form:
+#
+# docker run --rm \
+#  --env A --env B --env C --env D \
+#  --volume /path/to/D:/path/to/D
+#  alpine ...
+#
+# The output from the command is shown below the command.
+
+summon --provider /bin/echo --yaml "${secretsyml}" \
+ docker run --rm @SUMMONDOCKERARGS alpine sh -c '
+printenv A;
+printenv B;
+printenv C;
+cat $(printenv D);
+'
+# A_value with
+# multiple lines
+# B_value
+# C_value
+# D_value
+```
+## --env-file argument
+This is done on-demand by using the variable `@SUMMONENVFILE` in the arguments of the process
 you are running with Summon. This variable points to a memory-mapped file containing
 the variables and values from secrets.yml in VAR=VAL format.
 
@@ -27,7 +85,7 @@ Checking credentials
 Deploying application
 ```
 
-## Example
+### Example
 
 Let's say we have a deploy script that needs to access our application servers on
 AWS and pull the latest version of our code. It should record the outcome of the

--- a/docs/_includes/docker.md
+++ b/docs/_includes/docker.md
@@ -16,13 +16,21 @@ Since Summon has pluggable providers, you aren't locked into any one solution fo
 managing your secrets.
 
 Summon makes it easy to inject secrets as environment variables into your Docker
-containers by taking advantage of Docker's CLI arguments (`--env-file` or, `--env` and `--volume`. There are two options available. It's possible to mix and match as you see fit.
+containers by taking advantage of Docker's CLI arguments (`--env-file` or, `--env` and
+`--volume`. There are two options available. It's possible to mix and match as you see fit.
 
-## --env and --volume arguments
-This is done on-demand by using the variable `@SUMMONDOCKERARGS` in the arguments of the process
-you are running with Summon. This variable is replaced by combinations of the Docker arguments `--env` and `--volume` such that the secrets injected by summon are passed into the Docker container. The `--volume` arguments allow memory-mapped temporary files from variables with the `!file` tag to be resolvable inside the container.
+## Docker --env and --volume arguments
 
-**NOTE:** Using the `!file` tag with `@SUMMONDOCKERARGS` assumes that the Docker CLI is being run on the host that is used to create volume mounts to the container. For when this is not the case simply avoid using the `!file` tag, but be mindful that in that case you lose the benefits of memory-mapped temporary files.
+This is done on-demand by using the variable `@SUMMONDOCKERARGS` in the arguments of the
+ process you are running with Summon. This variable is replaced by combinations of the
+ Docker arguments `--env` and `--volume` such that the secrets injected by summon are
+ passed into the Docker container. The `--volume` arguments allow memory-mapped temporary
+ files from variables with the `!file` tag to be resolvable inside the container.
+
+**NOTE:** Using the `!file` tag with `@SUMMONDOCKERARGS` assumes that the Docker CLI is
+being run on the host that is used to create volume mounts to the container. For when
+this is not the case simply avoid using the `!file` tag, but be mindful that in that case
+you lose the benefits of memory-mapped temporary files.
 
 ```bash
 $ summon -p keyring.py -D env=dev docker run @SUMMONDOCKERARGS deployer
@@ -30,13 +38,13 @@ Checking credentials
 Deploying application
 ```
 
-### Example
-The example below demonstrates the use @SUMMONDOCKERARGS. For the sake of brevity
+### @SUMMONDOCKERARGS Example
+
+The example below demonstrates the use of @SUMMONDOCKERARGS. For the sake of brevity
 we use an inline `secrets.yml` and the `/bin/echo` provider. Some points to note:
-1. `summon` is
-invoking docker as the child process.
-2. `@SUMMONDOCKERARGS` is replaced with a combination of `--env` and `--volume`
-arguments.
+
+1. `summon` is invoking `docker` as the child process.
+2. `@SUMMONDOCKERARGS` is replaced with a combination of `--env` and `--volume` arguments.
 3. Variable `D` uses the `!file` tag and therefore is the only one that
 results in a `--volume` argument. The path to this variable inside the container
 is as it is on the host.
@@ -74,7 +82,7 @@ cat $(printenv D);
 # C_value
 # D_value
 ```
-## --env-file argument
+## Docker --env-file argument
 This is done on-demand by using the variable `@SUMMONENVFILE` in the arguments of the process
 you are running with Summon. This variable points to a memory-mapped file containing
 the variables and values from secrets.yml in VAR=VAL format.
@@ -85,7 +93,7 @@ Checking credentials
 Deploying application
 ```
 
-### Example
+### @SUMMONENVFILE Example
 
 Let's say we have a deploy script that needs to access our application servers on
 AWS and pull the latest version of our code. It should record the outcome of the

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/cyberark/summon
 
 require (
 	github.com/codegangsta/cli v1.20.0
+	github.com/docker/docker v20.10.2+incompatible
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,13 @@ github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNT
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v20.10.2+incompatible h1:vFgEHPqWBTp4pTjdLwjAA4bSo3gvIGOYwuJTlEjVBCw=
+github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/internal/command/subcommand.go
+++ b/internal/command/subcommand.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -11,16 +12,33 @@ import (
 // of an environment populated with secret values. Since we have to
 // clean up our temp directories, we remain resident and shuffle
 // signals around to the chld and back
-func runSubcommand(command []string, env []string) error {
+func runSubcommand(
+	command []string,
+	env []string,
+	Stdin io.Reader,
+	Stdout io.Writer,
+	Stderr io.Writer,
+) error {
 	binary, lookupErr := exec.LookPath(command[0])
 	if lookupErr != nil {
 		return lookupErr
 	}
 
 	runner := exec.Command(binary, command[1:]...)
-	runner.Stdin = os.Stdin
-	runner.Stdout = os.Stdout
-	runner.Stderr = os.Stderr
+
+	if Stdin == nil {
+		Stdin = os.Stdin
+	}
+	if Stdout == nil {
+		Stdout = os.Stdout
+	}
+	if Stderr == nil {
+		Stderr = os.Stderr
+	}
+
+	runner.Stdin = Stdin
+	runner.Stdout = Stdout
+	runner.Stderr = Stderr
 	runner.Env = env
 
 	signalChannel := make(chan os.Signal, 1)

--- a/internal/command/temp_factory.go
+++ b/internal/command/temp_factory.go
@@ -9,7 +9,7 @@ import (
 // DEVSHM is the default *nix shared-memory directory path
 const DEVSHM = "/dev/shm"
 
-// TempFactory handels transient files that require cleaning up
+// TempFactory handles transient files that require cleaning up
 // after the child process exits.
 type TempFactory struct {
 	path  string


### PR DESCRIPTION
Closes https://github.com/cyberark/summon/issues/194

@DOCKEROPTS is imagined to make it easier to lift summon secrets into docker. With usage like this in mind: 
```
summon docker run @SUMMONDOCKERARGS -it alpine
```

~Using the `!file` tag assumes that the file system where summon creates temporary files can be volume mounted to Docker.~
If you use the `!file` tag you're on your own for now.

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation