### PR TITLE
Update goreleaser brew.github to brew.tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,7 @@ brews:
     test: |
       system "#{bin}/summon", "-v"
 
-    github:
+    tap:
       owner: cyberark
       name: homebrew-tools
     skip_upload: true


### PR DESCRIPTION
Support for brews.github was removed in v0.152.0: https://goreleaser.com/deprecations/#brewsgithub

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation