### PR TITLE
Use map[string]string instead of []string internally

### DIFF
--- a/internal/command/action_test.go
+++ b/internal/command/action_test.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -42,14 +41,15 @@ func TestFormatForEnvString(t *testing.T) {
 				Path: "mysql1/password",
 				Tags: []secretsyml.YamlTag{secretsyml.Var},
 			}
-			envvar := formatForEnv(
+			k, v := formatForEnv(
 				"dbpass",
 				"mysecretvalue",
 				spec,
 				nil,
 			)
 
-			So(envvar, ShouldEqual, "dbpass=mysecretvalue")
+			So(k, ShouldEqual, "dbpass")
+			So(v, ShouldEqual, "mysecretvalue")
 		})
 		Convey("For files, VALUE should be the path to a tempfile containing the secret", func() {
 			tempFactory := NewTempFactory("")
@@ -59,15 +59,12 @@ func TestFormatForEnvString(t *testing.T) {
 				Path: "certs/webtier1/private-cert",
 				Tags: []secretsyml.YamlTag{secretsyml.File},
 			}
-			envvar := formatForEnv(
+			key, path := formatForEnv(
 				"SSL_CERT",
 				"mysecretvalue",
 				spec,
 				&tempFactory,
 			)
-
-			s := strings.Split(envvar, "=")
-			key, path := s[0], s[1]
 
 			So(key, ShouldEqual, "SSL_CERT")
 
@@ -84,8 +81,8 @@ func TestFormatForEnvString(t *testing.T) {
 
 func TestJoinEnv(t *testing.T) {
 	Convey("adds a trailing newline", t, func() {
-		result := joinEnv([]string{"foo", "bar"})
-		So(result, ShouldEqual, "foo\nbar\n")
+		result := joinEnv(map[string]string{"foo": "bar", "baz": "qux"})
+		So(result, ShouldEqual, "foo=bar\nbaz=qux\n")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR uses a `map[string]string` instead of a `[]string` in  ̀action.go` so that we have a more flexible structure to output the secrets in different ways (see #184).
For example we could easily have:
- quote multi-line secrets in @SUMMONENVFILE (if we find an agreement on this)
- have `@SUMMONJSONFILE` or `@SUMMONYAMLFILE` magic strings like `@SUMMONENVFILE`

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation