### PR TITLE
Update Gopass URL

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -89,7 +89,7 @@ Here are some specific examples of how you can use summon with your current tool
 * [Chef encrypted data bags](https://github.com/conjurinc/summon-chefapi)
 * [keyring](https://github.com/conjurinc/summon-keyring)
 * [Keepass kdbx database file](https://github.com/mskarbek/summon-keepass)
-* [Gopass](https://github.com/gopasspw/gopass/blob/master/docs/summon-provider.md)
+* [Gopass](https://github.com/gopasspw/gopass-summon-provider)
 * [AWS Secrets Manager](https://github.com/cyberark/summon-aws-secrets)
 
 Providers are easy to write. Given the identifier of a secret, they either return its value or an error.


### PR DESCRIPTION
### What does this PR do?
Gopass' Summon provider recently moved to https://github.com/gopasspw/gopass-summon-provider, so this updates the link in the documentation.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation