### PR TITLE
fix:tests: sort results of joinEnv for predictability

### DIFF
--- a/internal/command/action.go
+++ b/internal/command/action.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -200,6 +201,10 @@ func joinEnv(env map[string]string) string {
 	for k, v := range env {
 		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
 	}
+	
+	// Sort to ensure predictable results
+	sort.Strings(envs)
+
 	return strings.Join(envs, "\n") + "\n"
 }
 

--- a/internal/command/action_test.go
+++ b/internal/command/action_test.go
@@ -82,7 +82,7 @@ func TestFormatForEnvString(t *testing.T) {
 func TestJoinEnv(t *testing.T) {
 	Convey("adds a trailing newline", t, func() {
 		result := joinEnv(map[string]string{"foo": "bar", "baz": "qux"})
-		So(result, ShouldEqual, "foo=bar\nbaz=qux\n")
+		So(result, ShouldEqual, "baz=qux\nfoo=bar\n")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix flaky tests by having joinEnv return sorted results.

### What ticket does this PR close?
Connected to #193 (not clear if it fully resolves it)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation