### PR TITLE
Updating Go version to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.15
 
 WORKDIR /summon
 
@@ -7,9 +7,9 @@ ENV GOARCH=amd64
 
 COPY go.mod go.sum ./
 
-RUN apk add --no-cache bash \
-                       build-base \
-                       git && \
+RUN apt update -y && \
+    apt install -y bash \
+                   git && \
     go mod download && \
     go get -u github.com/jstemmer/go-junit-report && \
     go get -u github.com/axw/gocov/gocov && \

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.15-alpine
 
 RUN apk add --no-cache bash \
                        build-base \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ These can be installed with `dpkg -i summon_v*.deb` and
 
 ### Auto Install
 
-**Note** Check the release notes and select an appropriate release to ensure support for your version of Conjur.
+**Note** Check the
+[release notes](https://github.com/cyberark/summon/releases) and select an
+appropriate release to ensure support for your version of Conjur.
 
 Use the auto-install script. This will install the latest version of summon.
 The script requires sudo to place summon in `/usr/local/bin`.
@@ -74,7 +76,7 @@ called from and export the secret values to the environment of the command it wr
 
 *Example*
 
-You want to run script that requires AWS keys to list your EC2 instances.
+You want to run a script that requires AWS keys to list your EC2 instances.
 
 Define your keys in a `secrets.yml` file
 

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
 
-go 1.13
+go 1.15


### PR DESCRIPTION

### What does this PR do?
Updating Go version to 1.15
Changed the Dockerfiles to be based off the base Golang and not Alpine.
Added a couple nits in the README.md
Note also had to add "RUN gem install bundler:2.0.2" after removing the Alpine base image
due to a Ruby error.

### What ticket does this PR close?


Resolves #189 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation