### PR TITLE
WIP: Support for @SUMMONVARNAMES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.15-alpine
 
 WORKDIR /summon
 
@@ -7,9 +7,11 @@ ENV GOARCH=amd64
 
 COPY go.mod go.sum ./
 
-RUN apt update -y && \
-    apt install -y bash \
-                   git && \
+RUN apk add --no-cache bash \
+                       build-base \
+                       docker-cli \
+                       git && \
+    go mod download && \
     go mod download && \
     go get -u github.com/jstemmer/go-junit-report && \
     go get -u github.com/axw/gocov/gocov && \

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -2,6 +2,7 @@ FROM golang:1.15-alpine
 
 RUN apk add --no-cache bash \
                        build-base \
+                       docker-cli \
                        git \
                        libffi-dev \
                        ruby-bundler \

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/cyberark/summon
 
 require (
 	github.com/codegangsta/cli v1.20.0
+	github.com/docker/docker v20.10.2+incompatible
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,13 @@ github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNT
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v20.10.2+incompatible h1:vFgEHPqWBTp4pTjdLwjAA4bSo3gvIGOYwuJTlEjVBCw=
+github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/internal/command/subcommand.go
+++ b/internal/command/subcommand.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -11,16 +12,33 @@ import (
 // of an environment populated with secret values. Since we have to
 // clean up our temp directories, we remain resident and shuffle
 // signals around to the chld and back
-func runSubcommand(command []string, env []string) error {
+func runSubcommand(
+	command []string,
+	env []string,
+	Stdin io.Reader,
+	Stdout io.Writer,
+	Stderr io.Writer,
+) error {
 	binary, lookupErr := exec.LookPath(command[0])
 	if lookupErr != nil {
 		return lookupErr
 	}
 
 	runner := exec.Command(binary, command[1:]...)
-	runner.Stdin = os.Stdin
-	runner.Stdout = os.Stdout
-	runner.Stderr = os.Stderr
+
+	if Stdin == nil {
+		Stdin = os.Stdin
+	}
+	if Stdout == nil {
+		Stdout = os.Stdout
+	}
+	if Stderr == nil {
+		Stderr = os.Stderr
+	}
+
+	runner.Stdin = Stdin
+	runner.Stdout = Stdout
+	runner.Stderr = Stderr
 	runner.Env = env
 
 	signalChannel := make(chan os.Signal, 1)

--- a/internal/command/temp_factory.go
+++ b/internal/command/temp_factory.go
@@ -9,7 +9,7 @@ import (
 // DEVSHM is the default *nix shared-memory directory path
 const DEVSHM = "/dev/shm"
 
-// TempFactory handels transient files that require cleaning up
+// TempFactory handles transient files that require cleaning up
 // after the child process exits.
 type TempFactory struct {
 	path  string


### PR DESCRIPTION
### What does this PR do?

`@SUMMONVARNAMES` makes this possible, which avoids the multiline issues of `@SUMMONENVFILE`.
```
$ summon -p keyring.py -D env=dev env SUMMONVARNAMES=@SUMMONVARNAMES sh << EOL
docker run \$(printenv SUMMONVARNAMES | xargs printf -- '--env %s ' | xargs) deployer
EOL
```

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #199 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation