### PR TITLE
Fix installer when run with sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ do_download ${URL} ${ZIP_PATH}
 
 echo "Installing summon ${LATEST_VERSION} into /usr/local/bin"
 
-if sudo -h >/dev/null 2>&1; then
+if sudo -h >/dev/null 2>&1 && [ "$EUID" -ne 0 ]; then
   sudo tar -C /usr/local/bin -o -zxvf ${ZIP_PATH} >/dev/null
 else
   tar -C /usr/local/bin -o -zxvf ${ZIP_PATH} >/dev/null


### PR DESCRIPTION
### What does this PR do?
- `sudo ./install.sh` may generate the following error: `sudo: PAM account management error: Permission denied` and then stop execution
- This PR fixes the issue by checking user UID

### What ticket does this PR close?
- N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation