### PR TITLE
Add override for default provider path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Default provider path can be overridden via the `SUMMON_PROVIDER_PATH` environment variable,
+  resolving an issue where providers cannot be found when installed via homebrew in a non-default location.
+  [cyberark/summon#213](https://github.com/cyberark/summon/issues/213)
+
 ## [0.8.4] - 2021-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ VARIABLE_WITH_DEFAULT: !var:default='defaultvalue' path/to/variable
 * `-p, --provider <path-to-provider>` specify the path to the
 [provider](provider/README.md) summon should use.
 
-    If the provider is in the default path, `/usr/local/lib/summon/` (or
-    `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows) you can just
-    provide the name of the executable. If not, use a full path.
+    If you do not provide Summon with the full path to the provider, Summon
+    will look for the named executable in the directory defined by the `SUMMON_PROVIDER_PATH`
+    environment variable.  If this environment variable is not set, Summon
+    will look by default at `/usr/local/lib/summon` on Linux / Mac or
+    `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows.
 
 * `-f <path>` specify a location to a secrets.yml file, default 'secrets.yml' in current directory.
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -86,6 +86,12 @@ func expandPath(provider string) (string, error) {
 }
 
 func getDefaultPath() string {
+	pathOverride := os.Getenv("SUMMON_PROVIDER_PATH")
+
+	if pathOverride != "" {
+		return pathOverride
+	}
+
 	if runtime.GOOS == "windows" {
 		// Try to get the appropriate "Program Files" directory but if one doesn't
 		// exist, use a hardcoded value we think should be right.

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -120,10 +120,48 @@ func TestProviderResolutionViaDefaultPathWithOneProvider(t *testing.T) {
 	assert.EqualValues(t, provider, f.Name())
 }
 
+func TestProviderResolutionViaOverrideDefaultPathWithOneProvider(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("", "summontest")
+	defer os.RemoveAll(tempDir)
+	os.Setenv("SUMMON_PROVIDER_PATH", tempDir)
+	defer os.Setenv("SUMMON_PROVIDER_PATH", "")
+	DefaultPath = getDefaultPath()
+
+	f, err := ioutil.TempFile(DefaultPath, "")
+	defer os.RemoveAll(f.Name())
+	f.Chmod(755)
+	provider, err := Resolve("")
+
+	assert.Nil(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.EqualValues(t, provider, f.Name())
+}
+
 func TestProviderResolutionViaDefaultPathWithMultipleProviders(t *testing.T) {
 	tempDir, _ := ioutil.TempDir("", "summontest")
 	defer os.RemoveAll(tempDir)
 	DefaultPath = tempDir
+
+	// Create 2 exes in provider path
+	f1, _ := ioutil.TempFile(DefaultPath, "")
+	f2, _ := ioutil.TempFile(DefaultPath, "")
+	defer os.RemoveAll(f1.Name())
+	defer os.RemoveAll(f2.Name())
+
+	_, err := Resolve("")
+
+	assert.NotNil(t, err)
+}
+
+func TestProviderResolutionViaOverrideDefaultPathWithMultipleProviders(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("", "summontest")
+	defer os.RemoveAll(tempDir)
+	os.Setenv("SUMMON_PROVIDER_PATH", tempDir)
+	defer os.Setenv("SUMMON_PROVIDER_PATH", "")
+	DefaultPath = getDefaultPath()
 
 	// Create 2 exes in provider path
 	f1, _ := ioutil.TempFile(DefaultPath, "")


### PR DESCRIPTION
### What does this PR do?
- Adds an environment variable for override the default provider path
- Unit tests for coverage are included.  The change itself is simple, but review that the unit tests are actually covering the code changes is important

### What ticket does this PR close?
Resolves #213

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation