### PR TITLE
Build Summon for Apple silicon

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,19 @@ builds:
   - amd64
   main: ./cmd/main.go
 
+# Apple silicon support
+- id: summon-arm
+  binary: summon
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -tags=netgo
+  goos:
+  - darwin  # MacOS
+  goarch:
+  - arm64
+  main: ./cmd/main.go
+
 # Make a static build for Linux
 - id: summon-linux
   binary: summon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Build for Apple M1 silicon.
+  [cyberark/summon#216](https://github.com/cyberark/summon/issues/216)
+
 ### Fixed
 - Default provider path can be overridden via the `SUMMON_PROVIDER_PATH` environment variable,
   resolving an issue where providers cannot be found when installed via homebrew in a non-default location.


### PR DESCRIPTION
### What does this PR do?
GoReleaser builds Windows, Linux and Darwin-amd64 images but does
not build for the new Apple M1 hardware.

### What ticket does this PR close?
Resolves #216
Works towards [homebrew-tools](https://github.com/cyberark/homebrew-tools/issues/30)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation