### PR TITLE
Add `portable` mode for provider search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Build for Apple M1 silicon.
   [cyberark/summon#216](https://github.com/cyberark/summon/issues/216)
 
+### Added
+- Addded portable mode for provider directory search. If now global provider directory is
+  found providers are searched next to the `summon` executable in `<path_to_exe>/Providers/`
+  [cyberark/summon#164](https://github.com/cyberark/summon/issues/164)
+
 ### Fixed
 - Default provider path can be overridden via the `SUMMON_PROVIDER_PATH` environment variable,
   resolving an issue where providers cannot be found when installed via homebrew in a non-default location.

--- a/provider/README.md
+++ b/provider/README.md
@@ -9,7 +9,9 @@ Searches for a provider in this order:
 1. `providerArg`, passed in via CLI
 2. Environment variable `SUMMON_PROVIDER`
 3. Executable in `/usr/local/lib/summon`
-(or `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows).
+   (or `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows).
+4. If all of the above do net exist: look for Executable in 
+   `<path_to_summon_excutable>\Providers` (aka 'portable mode')
 
 `func Call(provider, specPath string) (string, error)`
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -7,11 +7,20 @@ Functions to resolve and call a Summon provider.
 Searches for a provider in this order:
 
 1. `providerArg`, passed in via CLI
-2. Environment variable `SUMMON_PROVIDER`
-3. Executable in `/usr/local/lib/summon`
-   (or `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows).
-4. If all of the above do net exist: look for Executable in 
-   `<path_to_summon_excutable>\Providers` (aka 'portable mode')
+2. environment variable `SUMMON_PROVIDER`
+3. check for directory `/usr/local/lib/summon`
+   (or `%ProgramW6432%\Cyberark Conjur\Summon\Providers` on Windows):
+   if it exist, search providers there
+4. if all of the above do not exist: use 
+   `<path_to_summon_excutable>\Providers` for searching providers (aka 'portable mode')
+
+*Attention*: the provider search is limited to the first directory found
+according to the priority list above. That means, if the system directory
+exist the local directory will never be searched, even if the system directory
+is empty. 
+
+In order to migrate from system directory configuration to a local provider directory you need to move all providers to the local provider dir *AND* delete
+the system directory.
 
 `func Call(provider, specPath string) (string, error)`
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -92,6 +92,8 @@ func getDefaultPath() string {
 		return pathOverride
 	}
 
+	dir := "/usr/local/lib/summon"
+
 	if runtime.GOOS == "windows" {
 		// Try to get the appropriate "Program Files" directory but if one doesn't
 		// exist, use a hardcoded value we think should be right.
@@ -100,10 +102,21 @@ func getDefaultPath() string {
 			programFilesDir = filepath.Join("C:", "Program Files")
 		}
 
-		return filepath.Join(programFilesDir, "Cyberark Conjur", "Summon", "Providers")
+		dir = filepath.Join(programFilesDir, "Cyberark Conjur", "Summon", "Providers")
 	}
 
-	return "/usr/local/lib/summon"
+	// found default installation directory
+	if _, err := os.Stat(dir); err == nil {
+		return dir
+	}
+
+	// finally: enable portable installation with Providers dir next to executable
+	// if the direcotries above were not found
+	exec, _ := os.Executable()
+	execDir := filepath.Dir(exec)
+	dir = filepath.Join(execDir, "Providers")
+
+	return dir
 }
 
 // GetAllProviders creates slice of all file names in the default path

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDefaultPortableProviderPath(t *testing.T) {
+	// CAVEAT: only works if no default installation within the test
+	// environment exists! getDefaultProvider falls back to portable
+	// only if no global install is found
+	DefaultPath = getDefaultPath()
+
+	exec, _ := os.Executable()
+	execDir := filepath.Dir(exec)
+	dir := filepath.Join(execDir, "Providers")
+	assert.EqualValues(t, dir, DefaultPath)
+}
+
 func TestNoProviderReturnsError(t *testing.T) {
 	// Point to a tempdir to avoid pollution from dev env
 	tempDir, _ := ioutil.TempDir("", "summontest")


### PR DESCRIPTION
### What does this PR do?
In order to allow `summon` to be used from arbitrary directories the
provider search path has been extended to also look in a `Providers`
sub-directory where the `summon` executable resides. With this `summon`
can be used more easily without installing it in a system path where
only administrators have write access.

### What ticket does this PR close?

#164 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

See #164 for feature discussion

This is my second attempt, please have a look at PR #163 where already some discussion has happened. All comments from then haven (hopefully) been implemented correctly.

