### PR TITLE
Update CONTRIBUTING.md for new apple image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ The following checklist should be followed when creating a release:
    - [ ] Binaries for smoke testing are found in the following directories
         - Linux:   `dist/goreleaser/summon-linux_linux_amd64`
         - MacOS:   `dist/goreleaser/summon_darwin_amd64`
+                   `dist/goreleaser/summon-darwin-arm64`
         - Windows: `dist/goreleaser/summon_windows_amd64`
 
 - [ ] Create a draft release:
@@ -91,7 +92,7 @@ The following checklist should be followed when creating a release:
   - [ ] Name the release the same as the tag.
   - [ ] Include in the release notes all changes from CHANGELOG that are being released.
     - [ ] Attach the relevant assets to the release, generated previously by `./build`:
-      - [ ] Attach `dist/goreleaser/summon-darwin-amd64.tar.gz` to release.
+      - [ ] Attach `dist/goreleaser/summon-darwin-a*64.tar.gz` to release.
       - [ ] Attach `dist/goreleaser/summon-linux-amd64.tar.gz` to release.
       - [ ] Attach `dist/goreleaser/summon-windows-amd64.tar.gz` to release.
       - [ ] Attach `dist/goreleaser/summon_v*.rpm` to release.


### PR DESCRIPTION
### What does this PR do?
In commit #217 support was added for the new Apple hardware.
This updates CONTRIBUTING.md with the new images.

### What ticket does this PR close?
Resolves N?A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation