### PR TITLE
Fix CI failures

### DIFF
--- a/build
+++ b/build
@@ -13,8 +13,9 @@ git fetch --tags  # jenkins does not do this automatically yet
 docker pull "${GORELEASER_IMAGE}"
 docker run --rm -t \
   --env GITHUB_TOKEN \
+  --entrypoint "/sbin/tini" \
   -v "$CURRENT_DIR:$MOUNT_DIR" \
   -w "$MOUNT_DIR" \
-  "${GORELEASER_IMAGE}" --rm-dist "$@"
+  "${GORELEASER_IMAGE}" -- sh -c "/entrypoint.sh --rm-dist $@ && rm ./dist/goreleaser/artifacts.json"
 
 echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
CI is failing due to a new feature with GoReleaser.

GoReleaser [2715](https://github.com/goreleaser/goreleaser/pull/2715) added an
artifacts.json file to the artifacts, but this file has user read permissions only and
is written by root and the other processes cannot read this file.
It is set to 0x600 [here](https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/artifacts/artifacts.go#L27)

```VirtualBox:~/cyberark/summon/dist/goreleaser$ ls -l
total 11364
-rw------- 1 root root    5887 Dec 23 10:57 artifacts.json
-rw-r--r-- 1 root root    4789 Dec 23 10:57 config.yaml
-rw-r--r-- 1 root root     781 Dec 23 10:57 SHA256SUMS.txt
-rw-r--r-- 1 root root 1442717 Dec 23 10:57 summon_0.9.0-SNAPSHOT-daaf95d_amd64.apk
-rw-r--r-- 1 root root 1442894 Dec 23 10:57 summon_0.9.0-SNAPSHOT-daaf95d_amd64.deb
-rw-r--r-- 1 root root 1441378 Dec 23 10:57 summon_0.9.0-SNAPSHOT-daaf95d_amd64.rpm
drwxr-xr-x 2 root root    4096 Dec 23 10:57 summon-arm_darwin_arm64
drwxr-xr-x 2 root root    4096 Dec 23 10:57 summon_darwin_amd64
-rw-r--r-- 1 root root 1464315 Dec 23 10:57 summon-darwin-amd64.tar.gz
-rw-r--r-- 1 root root 1445187 Dec 23 10:57 summon-darwin-arm64.tar.gz
-rw-r--r-- 1 root root 1439695 Dec 23 10:57 summon-linux-amd64.tar.gz
drwxr-xr-x 2 root root    4096 Dec 23 10:57 summon-linux_linux_amd64
-rw-r--r-- 1 root root    1246 Dec 23 10:57 summon.rb
drwxr-xr-x 2 root root    4096 Dec 23 10:57 summon_solaris_amd64
-rw-r--r-- 1 root root 1417291 Dec 23 10:57 summon-solaris-amd64.tar.gz
drwxr-xr-x 2 root root    4096 Dec 23 10:57 summon_windows_amd64
-rw-r--r-- 1 root root 1480462 Dec 23 10:57 summon-windows-amd64.zip
```
### Desired Outcome

CI should run

### Implemented Changes

Ignoring this new artifact.json file

### Connected Issue/Story

Resolves #[]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
