### PR TITLE
Update CONTRIBUTING.md for local builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ to ensure your contribution is compliant with our contributor license agreements
 To build versions for Linux, macOS and Windows:
 
 ```
-./build
+./build --snapshot
 ```
 
 Binaries will be placed in `dist/goreleaser`.


### PR DESCRIPTION
When doing a local build with `./build` there is an error with a missing environmental variable.
```
⨯ release failed after 0.00s error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN
```
For local builds the `--snapshot` option is needed as we're not trying to upload anything.

### Desired Outcome

The artifacts should build successfully.

### Implemented Changes

Changed the build instructions to `./build --snapshot`

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
