### PR TITLE
Update main and acceptance Dockerfile golang base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Update acceptance image Golang to 1.17 to fix CVE-2022-0778 and CVE-2022-1292.
+  [cyberark/summon#232](https://github.com/cyberark/summon/pull/232/)
+
 ## [0.9.1] - 2021-12-22
 ### Changed
 - Update go to 1.17 & switch to github.com/urfave/cli 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Security
-- Update acceptance image Golang to 1.17 to fix CVE-2022-0778 and CVE-2022-1292.
+- Update main and acceptance base images to Golang 1.17 to fix CVE-2022-0778 and CVE-2022-1292.
   [cyberark/summon#232](https://github.com/cyberark/summon/pull/232/)
 
 ## [0.9.1] - 2021-12-22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.17
 
 WORKDIR /summon
 

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.17-alpine
 
 RUN apk add --no-cache bash \
                        build-base \


### PR DESCRIPTION
Fixes CVE-2022-0778 and CVE-2022-1292.