### PR TITLE
Update golang.org/x/net to resolve CVE-2022-27664

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [0.9.5] - 2022-09-28
+### Changed
+- Upgrade Go to 1.19
+  [cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
+
 ### Security
 - Update aruba (0.6.2 -> 2.0.0), cucumber (2.0.0 -> 7.1.0) and other necessary
   dependencies in acceptance/Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cyberark/summon/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/cyberark/summon/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/cyberark/summon/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/cyberark/summon/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/cyberark/summon/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/cyberark/summon/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update aruba (0.6.2 -> 2.0.0), cucumber (2.0.0 -> 7.1.0) and other necessary
   dependencies in acceptance/Gemfile.lock
   [cyberark/summon#239](https://github.com/cyberark/summon/pull/239)
+- Update golang.org/x/net to v0.0.0-20220923203811-8be639271d50
+  [cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
 
 ## [0.9.4] - 2022-08-18
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.19
 
 WORKDIR /summon
 
@@ -11,9 +11,9 @@ RUN apt update -y && \
     apt install -y bash \
                    git && \
     go mod download && \
-    go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/axw/gocov/gocov && \
-    go get -u github.com/AlekSi/gocov-xml && \
+    go install github.com/jstemmer/go-junit-report@latest && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest && \
     mkdir -p /summon/output
 
 COPY . .

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.19-alpine
 
 RUN apk add --no-cache bash \
                        build-base \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cyberark/summon
 require (
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli v1.22.9
-	golang.org/x/net v0.0.0-20220812174116-3211cb980234
+	golang.org/x/net v0.0.0-20220923203811-8be639271d50
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -17,6 +17,8 @@ require (
 )
 
 go 1.19
+
+replace golang.org/x/net v0.0.0-20220812174116-3211cb980234 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
 replace gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.2.8
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-go 1.17
+go 1.19
 
 replace gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.2.8
 

--- a/go.sum
+++ b/go.sum
@@ -29,13 +29,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
 github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/net v0.0.0-20220923203811-8be639271d50 h1:vKyz8L3zkd+xrMeIaBsQ/MNVPVFSffdaU3ZyYlBGFnI=
+golang.org/x/net v0.0.0-20220923203811-8be639271d50/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/pkg/summon/version.go
+++ b/pkg/summon/version.go
@@ -1,4 +1,4 @@
 package summon
 
 // VERSION is the version of summon
-const VERSION = "0.9.4"
+const VERSION = "0.9.5"


### PR DESCRIPTION
### Desired Outcome

Remove version of golang.org/x/net that are vulnerable to CVE-2022-27664.

### Implemented Changes

- Upgrade Go to 1.19
- Upgrade golang.org/x/net to v0.0.0-20220923203811-8be639271d50
- Use replace statements redirecting prior golang.org/x/net versions to the updated version
- Prepare for release at 0.9.5 so security fixes can propagate to [cloudfoundry-conjur-buildpack](https://github.com/cyberark/cloudfoundry-conjur-buildpack)

### Connected Issue/Story

CyberArk internal issue link: CONJSE-1532

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
