### PR TITLE
Resolve CVE-2022-32149 by forcing golang.org/x/text to v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
 
 ### Security
+- Force golang.org/x/text to use v0.3.8 
+  [cyberark/summon#241](https://github.com/cyberark/summon/pull/241)
 - Update aruba (0.6.2 -> 2.0.0), cucumber (2.0.0 -> 7.1.0) and other necessary
   dependencies in acceptance/Gemfile.lock
   [cyberark/summon#239](https://github.com/cyberark/summon/pull/239)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ go 1.19
 
 replace golang.org/x/net v0.0.0-20220812174116-3211cb980234 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
+replace golang.org/x/text v0.3.7 => golang.org/x/text v0.3.8
+
 replace gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.2.8
 
 replace gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c => gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Force golang.org/x/text to v0.3.8

### Implemented Changes

Adds a replace statement.