### PR TITLE
Update go deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.9.5] - 2022-09-28
 ### Changed
+- Upgraded example Dockerfile to use python:3.11
+  [cyberark/summon#243](https://github.com/cyberark/summon/pull/243)
 - Upgrade Go to 1.19
   [cyberark/summon#240](https://github.com/cyberark/summon/pull/240)
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine3.10
+FROM python:3.11.0
 
 RUN mkdir /src
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,13 @@ replace golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 => golang.org/x/c
 
 replace golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 => golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
 
+replace golang.org/x/crypto v0.0.0-20211202192323-5770296d904e => golang.org/x/crypto v0.0.0-20211202192323-5770296d904e
+
 replace golang.org/x/net v0.0.0-20190620200207-3b0461eec859 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
 replace golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
+
+replace golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
 replace golang.org/x/net v0.0.0-20220722155237-a158d28d115b => golang.org/x/net v0.0.0-20220923203811-8be639271d50
 
@@ -33,6 +37,8 @@ replace golang.org/x/net v0.0.0-20220812174116-3211cb980234 => golang.org/x/net 
 replace golang.org/x/text v0.3.0 => golang.org/x/text v0.3.8
 
 replace golang.org/x/text v0.3.3 => golang.org/x/text v0.3.8
+
+replace golang.org/x/text v0.3.6 => golang.org/x/text v0.3.8
 
 replace golang.org/x/text v0.3.7 => golang.org/x/text v0.3.8
 


### PR DESCRIPTION
### Desired Outcome

Clean more vulnerable indirect dependencies from the build.

### Implemented Changes

- Updated example Dockerfile to use python:3.11 as a base image
- Added additional replace statements to go.mod to ensure vulnerable versions aren't used inadvertently.