### PR TITLE
Overwrite existing tags in CI if present

### DIFF
--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -20,6 +20,9 @@ RUN bundle install
 # Build summon
 WORKDIR /summon
 COPY . .
+RUN ls
+RUN ls ./dist
+RUN ls ./dist/goreleaser
 COPY ./dist/goreleaser/summon-linux_linux_amd64_v1/summon /bin/summon
 
 # Run tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
       steps {
         sh './build --snapshot'
         archiveArtifacts 'dist/goreleaser/'
+        sh 'ls .'
       }
     }
 
@@ -63,6 +64,7 @@ pipeline {
           // Create draft release
           sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./build"
           archiveArtifacts 'dist/goreleaser/'
+          sh "ls ."
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
           checkout scm
 
           // Create draft release
-          sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./build"
+          sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./build --snapshot"
           archiveArtifacts 'dist/goreleaser/'
           sh "ls ."
         }

--- a/build
+++ b/build
@@ -8,7 +8,7 @@ MOUNT_DIR="/summon"
 
 GORELEASER_IMAGE="goreleaser/goreleaser:latest"
 
-git fetch --tags  # jenkins does not do this automatically yet
+git fetch --tags -f  # jenkins does not do this automatically yet
 
 docker pull "${GORELEASER_IMAGE}"
 docker run --rm -t \


### PR DESCRIPTION
### Desired Outcome

Fix an issue where pushing a tag fails in CI due to a tag already existing from the automated release process

### Implemented Changes

Added `-f` flag to `git fetch --tags`


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
