### PR TITLE
fix: bring back --up flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Fix: bring back the --up flag [#254 --up is broken: open secrets.yml: no such file or directory](https://github.com/cyberark/summon/issues/254).
+
 ## [0.10.1] - 2024-08-14
 
 ### Changed

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -45,6 +45,17 @@ func RunSubprocess(sc *SubprocessConfig) (int, error) {
 
 	subs := convertSubsToMap(sc.Subs)
 
+	if sc.RecurseUp {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return 0, err
+		}
+		sc.Filepath, err = findInParentTree(sc.Filepath, currentDir)
+		if err != nil {
+			return 0, err
+		}
+	}
+
 	switch sc.YamlInline {
 	case "":
 		secrets, err = secretsyml.ParseFromFile(sc.Filepath, sc.Environment, subs)

--- a/pkg/summon/summon_test.go
+++ b/pkg/summon/summon_test.go
@@ -244,6 +244,7 @@ func TestDefaultVariableResolutionWithValue(t *testing.T) {
 		assert.Equal(t, expectedValue, string(content))
 	})
 }
+
 func TestConvertSubsToMap(t *testing.T) {
 	t.Run("Substitutions are returned as a map used later for interpolation", func(t *testing.T) {
 		input := []string{
@@ -332,24 +333,24 @@ func TestLocateFileRecurseUp(t *testing.T) {
 		assert.Equal(t, localFilePath, gotPath)
 	})
 
-	t.Run("Finds file in a higher working directory", func(t *testing.T) {
+	t.Run("Finds file in a directory above the working directory", func(t *testing.T) {
 		topDir, err := os.MkdirTemp("", "summon")
 		assert.NoError(t, err)
 		defer os.RemoveAll(topDir)
 
-		higherFilePath := filepath.Join(topDir, filename)
-		_, err = os.Create(higherFilePath)
+		fileAbovePath := filepath.Join(topDir, filename)
+		_, err = os.Create(fileAbovePath)
 		assert.NoError(t, err)
 
 		// Create a downwards directory hierarchy, starting from topDir
 		downDir := filepath.Join(topDir, "dir1", "dir2", "dir3")
-		err = os.MkdirAll(downDir, 0700)
+		err = os.MkdirAll(downDir, 0o700)
 		assert.NoError(t, err)
 
 		gotPath, err := findInParentTree(filename, downDir)
 		assert.NoError(t, err)
 
-		assert.Equal(t, higherFilePath, gotPath)
+		assert.Equal(t, fileAbovePath, gotPath)
 	})
 
 	t.Run("returns a friendly error if file not found", func(t *testing.T) {
@@ -412,6 +413,7 @@ func TestReturnStatusOfError(t *testing.T) {
 		assert.Equal(t, expected, err)
 	})
 }
+
 func TestNonInteractiveProviderFallback(t *testing.T) {
 	secrets := secretsyml.SecretsMap{
 		"key1": secretsyml.SecretSpec{Path: "path1"},

--- a/pkg/summon/summon_test.go
+++ b/pkg/summon/summon_test.go
@@ -319,12 +319,10 @@ func TestLocateFileRecurseUp(t *testing.T) {
 	filename := "test.txt"
 
 	t.Run("Finds file in current working directory", func(t *testing.T) {
-		topDir, err := os.MkdirTemp("", "summon")
-		assert.NoError(t, err)
-		defer os.RemoveAll(topDir)
+		topDir := t.TempDir()
 
 		localFilePath := filepath.Join(topDir, filename)
-		_, err = os.Create(localFilePath)
+		_, err := os.Create(localFilePath)
 		assert.NoError(t, err)
 
 		gotPath, err := findInParentTree(filename, topDir)
@@ -334,12 +332,10 @@ func TestLocateFileRecurseUp(t *testing.T) {
 	})
 
 	t.Run("Finds file in a directory above the working directory", func(t *testing.T) {
-		topDir, err := os.MkdirTemp("", "summon")
-		assert.NoError(t, err)
-		defer os.RemoveAll(topDir)
+		topDir := t.TempDir()
 
 		fileAbovePath := filepath.Join(topDir, filename)
-		_, err = os.Create(fileAbovePath)
+		_, err := os.Create(fileAbovePath)
 		assert.NoError(t, err)
 
 		// Create a downwards directory hierarchy, starting from topDir
@@ -354,9 +350,7 @@ func TestLocateFileRecurseUp(t *testing.T) {
 	})
 
 	t.Run("returns a friendly error if file not found", func(t *testing.T) {
-		topDir, err := os.MkdirTemp("", "summon")
-		assert.NoError(t, err)
-		defer os.RemoveAll(topDir)
+		topDir := t.TempDir()
 
 		// A unlikely to exist file name
 		nonExistingFileName := strconv.FormatInt(time.Now().Unix(), 10)
@@ -364,31 +358,27 @@ func TestLocateFileRecurseUp(t *testing.T) {
 			"unable to locate file specified (%s): reached root of file system",
 			nonExistingFileName)
 
-		_, err = findInParentTree(nonExistingFileName, topDir)
+		_, err := findInParentTree(nonExistingFileName, topDir)
 		assert.EqualError(t, err, wantErrMsg)
 	})
 
 	t.Run("returns a friendly error if file is an absolute path", func(t *testing.T) {
-		topDir, err := os.MkdirTemp("", "summon")
-		assert.NoError(t, err)
-		defer os.RemoveAll(topDir)
+		topDir := t.TempDir()
 
 		absFileName := "/foo/bar/baz"
 		wantErrMsg := "file specified (/foo/bar/baz) is an absolute path: will not recurse up"
 
-		_, err = findInParentTree(absFileName, topDir)
+		_, err := findInParentTree(absFileName, topDir)
 		assert.EqualError(t, err, wantErrMsg)
 	})
 
 	t.Run("returns a friendly error in unexpected circumstances (100% coverage)", func(t *testing.T) {
-		topDir, err := os.MkdirTemp("", "summon")
-		assert.NoError(t, err)
-		defer os.RemoveAll(topDir)
+		topDir := t.TempDir()
 
 		fileNameWithNulByte := "pizza\x00margherita"
 		wantErrMsg := "unable to locate file specified (pizza\x00margherita): stat"
 
-		_, err = findInParentTree(fileNameWithNulByte, topDir)
+		_, err := findInParentTree(fileNameWithNulByte, topDir)
 		assert.Contains(t, err.Error(), wantErrMsg)
 	})
 }


### PR DESCRIPTION
### Desired Outcome

Fix #254 (flag --up is not working any more).

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_

Added back the handling of --up flag, which has been removed by mistake (I think).

- _How should the reviewer approach this PR, especially if manual tests are required?_

Best reviewed commit-per-commit, considering the commit messages.

No manual tests are required; the PR adds an integration test to protect from this regression. See the comments I added in #254 for details.

### Connected Issue/Story

Resolves #254

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
