### PR TITLE
Fix properties template rendering

### DIFF
--- a/pkg/file_templates/secret_file_templates.go
+++ b/pkg/file_templates/secret_file_templates.go
@@ -42,8 +42,9 @@ func GetTemplate(name string, secretsMap map[string]*Secret) *template.Template 
 			// when the template is executed.
 			panic(fmt.Sprintf("secret alias %q not present in specified secrets for file", alias))
 		},
-		"b64enc":  b64encTemplateFunc,
-		"b64dec":  b64decTemplateFunc,
-		"htmlenc": htmlencTemplateFunc,
+		"b64enc":        b64encTemplateFunc,
+		"b64dec":        b64decTemplateFunc,
+		"htmlenc":       htmlencTemplateFunc,
+		"propertiesenc": propertiesencTemplateFunc,
 	})
 }

--- a/pkg/file_templates/template_functions.go
+++ b/pkg/file_templates/template_functions.go
@@ -56,6 +56,8 @@ func propertiesencTemplateFunc(value string) string {
 			b.WriteString(`\r`)
 		case '\t':
 			b.WriteString(`\t`)
+		case '\f':
+			b.WriteString(`\f`)
 		case ' ':
 			if i == 0 {
 				b.WriteByte('\\')

--- a/pkg/file_templates/template_functions.go
+++ b/pkg/file_templates/template_functions.go
@@ -3,6 +3,7 @@ package filetemplates
 import (
 	"encoding/base64"
 	"html"
+	"strings"
 )
 
 // Define template functions that don't need access to secrets in this file
@@ -34,4 +35,39 @@ func b64decTemplateFunc(encValue string) string {
 // producing well-formed XML output.
 func htmlencTemplateFunc(value string) string {
 	return html.EscapeString(value)
+}
+
+// propertiesenc escapes a string for use as a Java .properties value.
+//
+// The properties format does not use quotes as value delimiters, so literal
+// double quotes are preserved. Characters that Java properties treats as
+// syntactically meaningful or escape sequences are backslash-escaped.
+func propertiesencTemplateFunc(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+
+	for i, r := range value {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case ' ':
+			if i == 0 {
+				b.WriteByte('\\')
+			}
+			b.WriteRune(r)
+		case '=', ':', '#', '!':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/pushtofile/standard_templates.go
+++ b/pkg/pushtofile/standard_templates.go
@@ -23,7 +23,7 @@ var standardTemplates = map[string]standardTemplate{
 	"yaml":       {template: yamlTemplate, validateAlias: validateYAMLKey},
 	"json":       {template: jsonTemplate, validateAlias: validateJSONKey},
 	"dotenv":     {template: dotenvTemplate, validateAlias: validateBashVarName},
-	"properties": {template: dotenvTemplate, validateAlias: validatePropertyVarName},
+	"properties": {template: propertiesTemplate, validateAlias: validatePropertyVarName},
 	"bash":       {template: bashTemplate, validateAlias: validateBashVarName},
 }
 

--- a/pkg/pushtofile/standard_templates_definitions.go
+++ b/pkg/pushtofile/standard_templates_definitions.go
@@ -18,6 +18,12 @@ const dotenvTemplate = `
 {{- $secret.Alias }}={{ printf "%q" $secret.Value }}
 {{- end -}}
 `
+const propertiesTemplate = `
+{{- range $index, $secret := .SecretsArray -}}
+{{- if $index }}{{ "\n" }}{{ end }}
+{{- $secret.Alias }}={{ $secret.Value | propertiesenc }}
+{{- end -}}
+`
 const bashTemplate = `
 {{- range $index, $secret := .SecretsArray -}}
 {{- if $index }}{{ "\n" }}{{ end }}

--- a/pkg/pushtofile/standard_templates_test.go
+++ b/pkg/pushtofile/standard_templates_test.go
@@ -163,6 +163,14 @@ db.port=5432`),
 			},
 			assert: assertGoodOutput(`multiline=line1\nline2`),
 		},
+		{
+			description: "escapes form feeds",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "formfeed", Value: "\fstarts"},
+			},
+			assert: assertGoodOutput(`formfeed=\fstarts`),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/pushtofile/standard_templates_test.go
+++ b/pkg/pushtofile/standard_templates_test.go
@@ -72,8 +72,8 @@ alias2="secret value 2"`),
 			{Alias: "alias.1", Value: "secret value 1"},
 			{Alias: "alias2", Value: "secret value 2"},
 		},
-		assert: assertGoodOutput(`alias.1="secret value 1"
-alias2="secret value 2"`),
+		assert: assertGoodOutput(`alias.1=secret value 1
+alias2=secret value 2`),
 	},
 	{
 		description: "bash",
@@ -91,6 +91,94 @@ func Test_standardTemplates(t *testing.T) {
 	for _, tc := range standardTemplateTestCases {
 		tc.Run(t)
 	}
+}
+
+func TestPropertiesTemplateJavaCompatibleOutput(t *testing.T) {
+	testCases := []pushToWriterTestCase{
+		{
+			description: "simple scalar value is unquoted",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "db.host", Value: "myhost.example.com"},
+			},
+			assert: assertGoodOutput("db.host=myhost.example.com"),
+		},
+		{
+			description: "does not wrap values in quotes",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "plain", Value: "value"},
+				{Alias: "quoted", Value: `"value"`},
+			},
+			assert: assertGoodOutput(`plain=value
+quoted="value"`),
+		},
+		{
+			description: "aliases with dots are valid",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "db.host", Value: "myhost.example.com"},
+				{Alias: "db.port", Value: "5432"},
+			},
+			assert: assertGoodOutput(`db.host=myhost.example.com
+db.port=5432`),
+		},
+		{
+			description: "preserves literal double quotes",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "quoted", Value: `"value"`},
+			},
+			assert: assertGoodOutput(`quoted="value"`),
+		},
+		{
+			description: "escapes leading spaces only",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "space", Value: " leading and inner spaces"},
+			},
+			assert: assertGoodOutput(`space=\ leading and inner spaces`),
+		},
+		{
+			description: "escapes backslashes",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "path", Value: `C:\secrets\value`},
+			},
+			assert: assertGoodOutput(`path=C:\\secrets\\value`),
+		},
+		{
+			description: "escapes value separators and comment markers",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "syntax", Value: `a=b:c#!`},
+			},
+			assert: assertGoodOutput(`syntax=a\=b\:c\#\!`),
+		},
+		{
+			description: "escapes newlines",
+			template:    standardTemplates["properties"].template,
+			secrets: []*filetemplates.Secret{
+				{Alias: "multiline", Value: "line1\nline2"},
+			},
+			assert: assertGoodOutput(`multiline=line1\nline2`),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(t)
+	}
+}
+
+func TestDotenvTemplateKeepsQuotedOutput(t *testing.T) {
+	pushToWriterTestCase{
+		description: "dotenv output remains Go-quoted",
+		template:    standardTemplates["dotenv"].template,
+		secrets: []*filetemplates.Secret{
+			{Alias: "DB_HOST", Value: "myhost.example.com"},
+		},
+		assert: assertGoodOutput(`DB_HOST="myhost.example.com"`),
+	}.Run(t)
 }
 
 type aliasCharTestCase struct {
@@ -338,7 +426,7 @@ func TestStandardTemplate_ValidateAlias(t *testing.T) {
 	t.Run("validateAlias function is called when not nil", func(t *testing.T) {
 		expectedError := fmt.Errorf("validation failed")
 		template := standardTemplate{
-			template:   "test template",
+			template: "test template",
 			validateAlias: func(alias string) error {
 				if alias == "invalid" {
 					return expectedError


### PR DESCRIPTION
### Desired Outcome

`format: properties` should generate Java `.properties`-compatible output.

Before this change, the `properties` push-to-file format reused the dotenv template, which rendered values with Go `%q` quoting. That produced output like:

```properties
db.host="myhost.example.com"
```

Java `.properties` consumers treat double quotes as literal characters, not delimiters, so applications received `"myhost.example.com"` instead of `myhost.example.com`.

The desired outcome is for simple property values to render without introduced quote characters:

```properties
db.host=myhost.example.com
```

while preserving existing behavior for `dotenv`, `bash`, `json`, and `yaml` formats.

### Implemented Changes

This PR adds a dedicated Java properties rendering path instead of reusing `dotenvTemplate`.

Changes include:

* Added a `propertiesTemplate` for `format: properties`.
* Updated the standard template map so `properties` uses `propertiesTemplate` while continuing to use `validatePropertyVarName`.
* Added a `propertiesenc` template helper for Java properties value escaping.
* Preserved existing `dotenv` rendering behavior, including its current quoted value output.
* Added regression tests covering:

  * simple unquoted properties output
  * aliases with dots
  * literal double quote handling
  * leading spaces
  * backslashes
  * property separator/comment-related characters
  * newlines
  * unchanged dotenv rendering behavior

Reviewers should focus on whether the escaping behavior matches the intended Java properties compatibility contract and whether the scope is appropriate for `format: properties`.

No screenshots are relevant for this change.

### Connected Issue/Story

Resolves #264

CyberArk internal issue ID: N/A - external contribution

### Definition of Done

*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

* [ ] The CHANGELOG has been updated, or
* [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

* [x] This PR includes new unit and integration tests to go with the code
  changes, or
* [ ] The changes in this PR do not require tests

#### Documentation

* [ ] Docs (e.g. `README`s) were updated in this PR
* [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
* [x] This PR does not require updating any documentation

#### Behavior

* [ ] This PR changes product behavior and has been reviewed by a PO, or
* [ ] These changes are part of a larger initiative that will be reviewed later, or
* [ ] No behavior was changed with this PR

This PR changes behavior for `format: properties` to match the documented Java-style properties behavior. As an external contributor, I do not have access to CyberArk PO review; maintainers can route this internally if required.

#### Security

* [ ] Security architect has reviewed the changes in this PR,
* [ ] These changes are part of a larger initiative with a separate security review, or
* [x] There are no security aspects to these changes
